### PR TITLE
Ggg 145 release to maven central

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,30 @@
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github
+        settings-path: ${{ github.workspace }}
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,3 +28,26 @@ jobs:
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
+
+  publish-to-central:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17 for Central
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: ossrh
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Publish to Maven Central
+      run: mvn clean deploy -P release -DskipTests
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <revision>4.1</revision>
+        <revision>5.0</revision>
         <!-- is overwritten by CI. Default is 999999-SNAPSHOT to ensure that the version is higher than the last release, when developing locally -->
         <changelist>.999999-SNAPSHOT</changelist>
 
@@ -172,14 +172,14 @@
     </dependencyManagement>
     <distributionManagement>
         <repository>
-            <id>artifactory-libs-releases</id>
-            <name>Artifactory</name>
-            <url>https://artifactory.sikt.no/artifactory/libs-releases/</url>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/sikt-no/graphitron</url>
         </repository>
         <snapshotRepository>
-            <id>artifactory-libs-snapshots</id>
-            <name>Artifactory</name>
-            <url>https://artifactory.sikt.no/artifactory/libs-snapshots/</url>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/sikt-no/graphitron</url>
         </snapshotRepository>
     </distributionManagement>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
 
     <version>${revision}${changelist}</version>
 
+    <name>Graphitron</name>
+    <description>Graphitron is a code generation tool that creates source code by linking GraphQL schemas to underlying database models</description>
+    <url>https://github.com/sikt-no/graphitron</url>
+
     <modules>
         <module>graphitron</module>
         <module>graphitron-common</module>
@@ -23,8 +27,7 @@
 
     <properties>
         <revision>5.0</revision>
-        <!-- is overwritten by CI. Default is 999999-SNAPSHOT to ensure that the version is higher than the last release, when developing locally -->
-        <changelist>.999999-SNAPSHOT</changelist>
+        <changelist>.1</changelist>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -170,7 +173,9 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <distributionManagement>
+        <!-- GitHub Packages -->
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
@@ -182,9 +187,11 @@
             <url>https://maven.pkg.github.com/sikt-no/graphitron</url>
         </snapshotRepository>
     </distributionManagement>
+
     <scm>
+        <connection>scm:git:git://github.com/sikt-no/graphitron.git</connection>
+        <developerConnection>scm:git:ssh://github.com:sikt-no/graphitron.git</developerConnection>
         <url>https://github.com/sikt-no/graphitron.git</url>
-        <developerConnection>scm:git:git@git@github.com:sikt-no/graphitron.git</developerConnection>
     </scm>
     <licenses>
         <license>
@@ -193,6 +200,45 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <name>Andrea Nakstad</name>
+            <email>andrea.nakstad@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+        <developer>
+            <name>A.C.</name>
+            <email>andrzej.cabala@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+        <developer>
+            <name>Christoffer Hellerud Hansen</name>
+            <email>christoffer.hansen@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+        <developer>
+            <name>Filip Folkesson</name>
+            <email>filip.folkesson@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+        <developer>
+            <name>Jens Kilde Mjelva</name>
+            <email>jens.kilde.mjelva@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+        <developer>
+            <name>Kenneth Pettersen Lund</name>
+            <email>kenneth.lund@sikt.no</email>
+            <organization>Sikt</organization>
+            <organizationUrl>http://www.sikt.no</organizationUrl>
+        </developer>
+    </developers>
 
     <build>
         <pluginManagement>
@@ -277,6 +323,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.15.1</version>
                 </plugin>
@@ -284,12 +336,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.4</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.4</version>
                 </plugin>
 
@@ -303,6 +349,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.7.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -384,6 +440,81 @@
                 <maven.test.skip>true</maven.test.skip>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
             </properties>
+        </profile>
+        <profile>
+            <!-- This profile is used to build the project for release to the Maven Central Repository (OSSRH).
+             It includes the necessary plugins and configurations for signing, generating sources and javadocs,
+            and deploying to OSSRH. -->
+            <id>release</id>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Central Repository OSSRH</name>
+                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <name>OSSRH Snapshots</name>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Adds configuration for releasing to maven central.

Some more steps are required outside of the code base before releasing can be done:

1. Set up Sonatype OSSRH Account
2. Generate and publish GPG Keys
3. Confiure OSSHR and GPG key secrets in GitHub
