### PR TITLE
updates release configuration to use Maven Central Publisher Portal

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        server-id: ossrh
+        server-id: central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -26,6 +26,6 @@ jobs:
     - name: Build and publish to Maven Central
       run: mvn --batch-mode --errors clean deploy -P release
       env:
-        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        MAVEN_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -349,9 +349,9 @@
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -435,32 +435,24 @@
             </properties>
         </profile>
         <profile>
-            <!-- This profile is used to build the project for release to the Maven Central Repository (OSSRH).
-             It includes the necessary plugins and configurations for signing, generating sources and javadocs,
-            and deploying to OSSRH. -->
+            <!-- This profile is used to build the project for release to the Maven Central Publisher Portal.
+             It includes the necessary plugins and configurations for signing, generating sources and Javadocs,
+            and deploying to the Central Portal. -->
             <id>release</id>
             <distributionManagement>
                 <repository>
-                    <id>ossrh</id>
-                    <name>Central Repository OSSRH</name>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <id>central</id>
                 </repository>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <name>OSSRH Snapshots</name>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
             </distributionManagement>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
- https://central.sonatype.org/publish/publish-portal-maven/

Publishing with the previous configuration fails as it attempts to use Publisher Portal token when publishing via OSSRH.

This is the desired way to publish,

>  "The legacy OSSRH publishing service will be sunset on June 30th, 2025"
> (https://central.sonatype.org/publish/publish-guide/)