### PR TITLE
Fixes Javadoc generation errors by excluding test classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,10 @@
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Only include main sources, not tests -->
+                                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Restricts maven-javadoc-plugin to only process main source files by explicitly setting the sourcepath configuration parameter.