### PR TITLE
GGG Run class generators in parallel.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generate/GraphQLGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generate/GraphQLGenerator.java
@@ -89,10 +89,14 @@ public class GraphQLGenerator {
      * @param generators The generators that should be executed.
      */
     public static void generate(List<ClassGenerator> generators) {
-        for (var g : generators) {
+        var last = generators.subList(generators.size() - 1, generators.size()).get(0); // The wiring generator must go last.
+        var other = generators.subList(0, generators.size() - 1);
+        other.stream().parallel().forEach(g -> {
             g.generateAllToDirectory(GeneratorConfig.outputDirectory(), GeneratorConfig.outputPackage());
             LOGGER.info("Generated sources to: {}.{}", GeneratorConfig.outputPackage(), g.getDefaultSaveDirectoryName());
-        }
+        });
+        last.generateAllToDirectory(GeneratorConfig.outputDirectory(), GeneratorConfig.outputPackage());
+        LOGGER.info("Generated sources to: {}.{}", GeneratorConfig.outputPackage(), last.getDefaultSaveDirectoryName());
     }
 
     public static Map<String, List<String>> generateAsStrings(List<ClassGenerator> generators) {


### PR DESCRIPTION
Bonus content:
The class generators run in parallel. This saved about 15%-25% Graphitron run time depending on project size (15% example, 25% FS).