### PR TITLE
fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -3,6 +3,9 @@
 
 name: CI build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/sikt-no/graphitron/security/code-scanning/1](https://github.com/sikt-no/graphitron/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a basic CI build process, the workflow only requires read access to the repository contents. We will add `permissions: contents: read` at the root level of the workflow to apply this restriction to all jobs. This ensures that the `GITHUB_TOKEN` has the minimal permissions necessary for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
