### PR TITLE
removes unused quarkus ci profile

### DIFF
--- a/graphitron-example/graphitron-example-server/src/main/resources/application.yaml
+++ b/graphitron-example/graphitron-example-server/src/main/resources/application.yaml
@@ -30,12 +30,3 @@ application:
       category:
         "org.jooq":
           level: WARN
-
-# This configuration is used when running tests on CI
-"%ci":
-  quarkus:
-    profile:
-      parent: test
-    datasource:
-      jdbc:
-        url: jdbc:postgresql://docker:${quarkus.datasource.devservices.port}/${quarkus.datasource.devservices.properties.POSTGRES_DB}


### PR DESCRIPTION
- no longer needed after move from glab to github