### PR TITLE
Fix bug in equals method for FieldReference

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/containedtypes/FieldReference.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/containedtypes/FieldReference.java
@@ -159,7 +159,7 @@ public class FieldReference {
             var ref = (FieldReference) obj;
             return ref.hasTable() == this.hasTable() && (!this.hasTable() || ref.getTable().equals(this.getTable()))
                     && ref.hasKey() == this.hasKey() && (!this.hasKey() || ref.getKey().equals(this.getKey()))
-                    && ref.getTableCondition().equals(this.tableCondition);
+                    && ref.hasTableCondition() == this.hasTableCondition() && (!this.hasTableCondition() || ref.getTableCondition().equals(this.tableCondition));
         } else {
             return false;
         }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InterfaceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InterfaceTest.java
@@ -162,6 +162,12 @@ public class InterfaceTest extends ValidationTest {
     }
 
     @Test
+    @DisplayName("Matching reference directive on field in type implementing single table interface")
+    void referenceMatches() {
+        assertDoesNotThrow(() -> generateFiles("singleTableInterface/referenceMatches"));
+    }
+
+    @Test
     @DisplayName("Mismatch in reference directive on field in type implementing single table interface")
     void referenceInTypeConflict() {
         assertErrorsContain("singleTableInterface/referenceInTypeConflict",

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/interface/singleTableInterface/referenceMatches/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/interface/singleTableInterface/referenceMatches/schema.graphqls
@@ -1,0 +1,17 @@
+type Query {
+    address: Address
+}
+
+interface Address @table(name: "ADDRESS") @discriminate(on: "DISTRICT"){
+    postalCode: String @field(name: "POSTAL_CODE")
+}
+
+type AddressInDistrictOne implements Address @table(name: "ADDRESS") @discriminator(value: "ONE") {
+    postalCode: String @field(name: "POSTAL_CODE")
+    customer: CustomerTable @reference(references: [{key: "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY"}])
+}
+
+type AddressInDistrictTwo implements Address @table(name: "ADDRESS") @discriminator(value: "TWO") {
+    postalCode: String @field(name: "POSTAL_CODE")
+    customer: CustomerTable @reference(references: [{key: "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY"}])
+}


### PR DESCRIPTION
Utdanningsregisteret rapporterte at ved dette skjemaet:

```
interface ApiHendelser @table(name: "API_HENDELSE") @discriminate(on: "HENDELSESTYPEKODE") {
  hendelsestypenavn: String! @reference(references: [{key: "....."}])
.....
}
```

Fikk de denne feilen:

`[ERROR] Failed to execute goal no.sikt:graphitron-maven-plugin:4.2.r345:generate (generate) on project utdanningsregisteret-graphql-spec: Execution generate of goal no.sikt:graphitron-maven-plugin:4.2.r345:generate failed: Cannot invoke "no.sikt.graphitron.definitions.sql.SQLCondition.equals(Object)" because the return value of "no.sikt.graphitron.definitions.fields.containedtypes.FieldReference.getTableCondition()" is null -> [Help 1]`

Årsaken er manglende nullsjekk i FieldReference sin equals metode som fikses her.