### PR TITLE
Rename mise build task to build-all

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,7 +6,7 @@ java = "17"
 description = "Maven clean"
 run = "mvn clean"
 
-[tasks.build]
+[tasks.build-all]
 description = "Run maven install"
 run = "mvn install"
 


### PR DESCRIPTION
I want my mise `build` task to build from the `graphitron-java-codegen` module, instead of building the whole project (including javapoet).
I doubt we want to build the whole project too often, so maybe we should rename this task to `build-all`?