### PR TITLE
Add unions/interfaces to recordTypes map + create helper methods

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
@@ -48,12 +48,6 @@ abstract public class ResolverMethodGenerator extends AbstractSchemaMethodGenera
         if (processedSchema.isRecordType(field)) {
             return processedSchema.getRecordType(field).getGraphClassName();
         }
-        if (processedSchema.isInterface(field)) {
-            return processedSchema.getInterface(field).getGraphClassName();
-        }
-        if (processedSchema.isUnion(field)) {
-            return processedSchema.getUnion(field).getGraphClassName();
-        }
         if (processedSchema.isEnum(field)) {
             return processedSchema.getEnum(field).getGraphClassName();
         }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
@@ -57,9 +57,7 @@ public class ResolverKeyHelpers {
      * @return The key used in the first step when resolving a resolver field
      */
     public static Key<?> findKeyForResolverField(GenerationField field, ProcessedSchema processedSchema) {
-        var container = processedSchema.isInterface(field.getContainerTypeName()) ?
-                processedSchema.getInterface(field.getContainerTypeName())
-                : processedSchema.getObjectOrConnectionNode(field.getContainerTypeName());
+        var container = processedSchema.getRecordType(field.getContainerTypeName());
 
         var containerTypeTable = container.hasTable() ?
                 container.getTable()

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/FetchContext.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/FetchContext.java
@@ -72,14 +72,10 @@ public class FetchContext {
         this.recCounter = recCounter;
         this.processedSchema = processedSchema;
 
-         if (processedSchema.isInterface(referenceObjectField)) {
-             referenceObject = processedSchema.getInterface(referenceObjectField);
-         } else if (processedSchema.isUnion(referenceObjectField)) {
-             referenceObject = processedSchema.getUnion(referenceObjectField);
-         } else if (referenceObjectField.hasNodeID()) {
+        if (referenceObjectField.hasNodeID()) {
              referenceObject = processedSchema.getObject(referenceObjectField.getNodeIdTypeName());
          } else {
-             referenceObject = processedSchema.getObjectOrConnectionNode(referenceObjectField);
+             referenceObject = processedSchema.getRecordType(referenceObjectField);
          }
 
         this.joinSet = joinSet;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchDBMethodGenerator.java
@@ -161,7 +161,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 .getReferenceObject()
                 .getFields()
                 .stream()
-                .filter(f -> !(f.isResolver() && (processedSchema.isObject(f) || processedSchema.isInterface(f) || processedSchema.isUnion(f))))
+                .filter(f -> !(f.isResolver() && (processedSchema.isRecordType(f))))
                 .collect(Collectors.toList());
 
         var rowElements = new ArrayList<CodeBlock>();

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchMultiTableDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchMultiTableDBMethodGenerator.java
@@ -169,7 +169,7 @@ public class FetchMultiTableDBMethodGenerator extends FetchDBMethodGenerator {
 
     private CodeBlock createMapping(ObjectField target, Set<ObjectDefinition> implementations) {
         var code = CodeBlock.builder();
-        var graphClassName = processedSchema.isInterface(target) ? processedSchema.getInterface(target).getGraphClassName() : processedSchema.getUnion(target).getGraphClassName();
+        var graphClassName = processedSchema.getRecordType(target).getGraphClassName();
         var mapping = createMappingContent(graphClassName, implementations, target.hasForwardPagination());
         if (target.isIterableWrapped() || target.hasForwardPagination()) {
             code.add(".map(\n$L\n);", mapping);
@@ -403,13 +403,13 @@ public class FetchMultiTableDBMethodGenerator extends FetchDBMethodGenerator {
         return getLocalObject()
                 .getFields()
                 .stream()
-                .filter(it -> processedSchema.isInterface(it) || (processedSchema.isUnion(it) && !it.getName().equals(FEDERATION_ENTITIES_FIELD.getName())))
+                .filter(processedSchema::isMultiTableField)
+                .filter(it -> !it.getName().equals(FEDERATION_ENTITIES_FIELD.getName()))
                 .filter(it -> !it.getTypeName().equals(NODE_TYPE.getName()))
-                .filter(it-> !processedSchema.isInterface(it) || !processedSchema.getInterface(it).hasDiscriminator())
                 .filter(GenerationField::isGeneratedWithResolver)
                 .filter(it -> !it.hasServiceReference())
                 .flatMap(it -> generateWithSubselectMethods(it).stream())
                 .filter(it -> !it.code().isEmpty())
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchSingleTableInterfaceDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/fetch/FetchSingleTableInterfaceDBMethodGenerator.java
@@ -148,7 +148,7 @@ public class FetchSingleTableInterfaceDBMethodGenerator extends FetchDBMethodGen
                 .stream()
                 .filter(processedSchema::isInterface)
                 .filter(it -> !it.getTypeName().equals(NODE_TYPE.getName()))
-                .filter(it -> processedSchema.getInterface(it.getTypeName()).hasDiscriminator())
+                .filter(processedSchema::isSingleTableInterface)
                 .filter(GenerationField::isGeneratedWithResolver)
                 .filter(it -> !it.hasServiceReference())
                 .map(this::generate)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/datafetchers/typeresolvers/TypeNameMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/datafetchers/typeresolvers/TypeNameMethodGenerator.java
@@ -40,15 +40,8 @@ public class TypeNameMethodGenerator extends AbstractSchemaMethodGenerator<TypeR
     }
 
     private Set<ObjectDefinition> getComponents(TypeResolverTarget target) {
-        if (processedSchema.isInterface(target.getName())) {
-            return processedSchema.getImplementationsForInterface((InterfaceDefinition) target);
-        }
-        if (processedSchema.isUnion(target.getName())) {
-            return ((UnionDefinition) target)
-                    .getFieldTypeNames()
-                    .stream()
-                    .map(processedSchema::getObject)
-                    .collect(Collectors.toSet());
+        if (processedSchema.isInterface(target.getName()) || processedSchema.isUnion(target.getName())) {
+            return processedSchema.getTypesFromInterfaceOrUnion(target.getName());
         }
         return Set.of();
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -107,8 +107,7 @@ public class ProcessedDefinitionsValidator {
         schema.getObjects()
                 .values().stream()
                 .flatMap(o -> o.getFields().stream())
-                .filter(field -> (schema.isInterface(field) && !schema.getInterface(field).hasTable())
-                        || schema.isUnion(field))
+                .filter(schema::isMultiTableField)
                 .filter(field -> !field.getTypeName().equals(NODE_TYPE.getName()))
                 .filter(field -> !field.getTypeName().equals(FEDERATION_SERVICE_FIELD.getName()))
                 .filter(field -> !field.getTypeName().equals(FEDERATION_ENTITY_UNION.getName()))
@@ -649,7 +648,7 @@ public class ProcessedDefinitionsValidator {
 
                     var singleTableInterfaces = implementedInterfaces.stream()
                             .filter(it -> !it.equals(NODE_TYPE.getName()))
-                            .filter(it -> schema.getInterface(it).hasDiscriminator())
+                            .filter(schema::isSingleTableInterface)
                             .toList();
 
                     if (singleTableInterfaces.isEmpty() && objectDefinition.hasDiscriminator()) {


### PR DESCRIPTION
I forbindelse med [GG-24](https://sikt.atlassian.net/browse/GG-24) så endte jeg opp på en liten refaktoreringstangent som jeg tenker det er bedre å ta i egen MR.
Vi har mange if'er på interface og unions rundt omkring, så jeg har prøvd å samle logikken litt her.

I tillegg har jeg lagt til interface og unions i `recordTypes`-mappet siden de extender `RecordObjectSpecification`-klassen, men det er muligens kontroversielt 😁