### PR TITLE
GG-24 keep key for single table interface fields

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
@@ -63,9 +63,7 @@ public class ResolverKeyHelpers {
                 container.getTable()
                 : processedSchema.getPreviousTableObjectForObject(container).getTable();
 
-        var tableFromFieldType = processedSchema.isObject(field.getTypeName()) ?
-                processedSchema.getObjectOrConnectionNode(field.getTypeName()).getTable()
-                : processedSchema.isInterface(field.getTypeName()) ? processedSchema.getInterface(field.getTypeName()).getTable() : null;
+        var tableFromFieldType = processedSchema.isRecordType(field) ? processedSchema.getRecordType(field).getTable() : null;
 
         ForeignKey<?, ?> foreignKey;
         var primaryKeyOptional = getPrimaryKeyForTable(containerTypeTable.getName());

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/common/configuration/SchemaComponent.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/common/configuration/SchemaComponent.java
@@ -41,6 +41,9 @@ public enum SchemaComponent {
     DUMMY_INPUT_RECORD("basic/DummyInputRecord", Set.of(ID_RECORD)),
     DUMMY_CONNECTION("basic/DummyConnection", DUMMY_TYPE, PAGE_INFO),
 
+    ADDRESS_BY_DISTRICT("basic/AddressByDistrict"),
+    ADDRESS_BY_DISTRICT_CONNECTION("basic/AddressByDistrictConnection"),
+
     SOMEUNION_CONNECTION("basic/SomeUnionConnection"),
 
     MUTATION_RESPONSE("basic/MutationResponse"),

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
-import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_CONNECTION;
-import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
+import static no.sikt.graphitron.common.configuration.SchemaComponent.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DTOSplitQueryTest extends DTOGeneratorTest {
@@ -180,5 +179,23 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
         assertThatThrownBy(() -> generateFiles("subtype"))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Cannot find implicit key for field 'someType' in type 'VacationDestination'.");
+    }
+
+    @Test
+    @DisplayName("Field referencing single table interface")
+    void referencingSingleTableInterface() {
+        assertGeneratedContentContains("referencingSingleTableInterface", Set.of(ADDRESS_BY_DISTRICT),
+                "City(Record1<Long> primaryKey)",
+                "this.addressesKey = primaryKey;"
+        );
+    }
+
+    @Test
+    @DisplayName("Field referencing single table interface connection")
+    void referencingSingleTableInterfaceConnection() {
+        assertGeneratedContentContains("referencingSingleTableInterfaceConnection", Set.of(ADDRESS_BY_DISTRICT, ADDRESS_BY_DISTRICT_CONNECTION),
+                "City(Record1<Long> primaryKey)",
+                "this.addressesKey = primaryKey;"
+        );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
@@ -67,6 +67,15 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
     }
 
     @Test
+    @DisplayName("Primary key columns should be selected in previous query for field returning single table interface")
+    void previousQuerySingleTableInterface() {
+        assertGeneratedContentContains(
+                "previousQuerySingleTableInterface", Set.of(ADDRESS_BY_DISTRICT),
+                "row(DSL.row(_city.CITY_ID)).mapping"
+        );
+    }
+
+    @Test
     @DisplayName("Table path")
     void table() {
         assertGeneratedContentContains(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/AddressByDistrict.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/AddressByDistrict.graphqls
@@ -1,0 +1,11 @@
+interface AddressByDistrict @table(name: "ADDRESS") @discriminate(on: "DISTRICT"){
+    postalCode: String @field(name: "POSTAL_CODE")
+}
+
+type AddressInDistrictOne implements Address @table(name: "ADDRESS") @discriminator(value: "ONE") {
+    postalCode: String @field(name: "POSTAL_CODE")
+}
+
+type AddressInDistrictTwo implements Address @table(name: "ADDRESS") @discriminator(value: "TWO") {
+    postalCode: String @field(name: "POSTAL_CODE")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/AddressByDistrictConnection.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/AddressByDistrictConnection.graphqls
@@ -1,0 +1,10 @@
+type AddressByDistrictConnection {
+  edges: [AddressByDistrictConnectionEdge]
+  pageInfo: PageInfo
+  nodes: [AddressByDistrict!]!
+}
+
+type AddressByDistrictConnectionEdge {
+  cursor: String
+  node: AddressByDistrict
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingSingleTableInterface/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingSingleTableInterface/schema.graphqls
@@ -1,0 +1,3 @@
+type City @table {
+    addresses: [AddressByDistrict] @splitQuery
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingSingleTableInterfaceConnection/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingSingleTableInterfaceConnection/schema.graphqls
@@ -1,0 +1,3 @@
+type City @table {
+    addresses(first: Int = 100, after: String): AddressByDistrictConnection
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQuerySingleTableInterface/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQuerySingleTableInterface/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+    query: City
+}
+
+type City @table {
+    addresses: [AddressByDistrict] @splitQuery
+}


### PR DESCRIPTION
Commit e47acd956503ad037b209c4979b9fa40c46bac69 står i egen [PR](https://github.com/sikt-no/graphitron/pull/45) og kan sees bort i fra her (derfor står denne som draft inntil den andre PRen blir merget).

Denne PRen er forarbeid for både [GG-12](https://sikt.atlassian.net/browse/GG-12) og [GG-24](https://sikt.atlassian.net/browse/GG-24), og handler om å ta vare på nøkkelverdier som skal brukes videre i framtidige interfacespørringer (kun single table) utenom query. Multitabell må tas i ny runde og blir noe mer komplisert siden det blir snakk om flere nøkler.

Det er ikke mulig å funksjonelt teste det som gjøres her enda, siden nøkkelverdiene ikke er tatt bruk videre i splitQuery-spørringen enda