### PR TITLE
GG Allow context variables for kickstart resolvers.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
@@ -300,4 +300,16 @@ abstract public class ResolverMethodGenerator extends AbstractSchemaMethodGenera
 
         return wrapNotNull(sourceName, code.add(context.wrapFields(fieldCode.build())).build());
     }
+
+    protected CodeBlock declareContextArgs(ObjectField target) {
+        if (!target.hasServiceReference() || target.getService().getContextFields().isEmpty()) {
+            return empty();
+        }
+
+        var code = CodeBlock
+                .builder()
+                .add(declare(GRAPH_CONTEXT_NAME, asMethodCall(VARIABLE_ENV, METHOD_GRAPH_CONTEXT)));
+        target.getService().getContextFields().forEach((name, type) -> code.add(declare("_" + name, asCast(type, CodeBlock.of("$N.get($S)", GRAPH_CONTEXT_NAME, name)))));
+        return code.build();
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/datafetchers/operations/OperationMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/datafetchers/operations/OperationMethodGenerator.java
@@ -53,18 +53,6 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
                 .build();
     }
 
-    private CodeBlock declareContextArgs(ObjectField target) {
-        if (!target.hasServiceReference() || target.getService().getContextFields().isEmpty()) {
-            return empty();
-        }
-
-        var code = CodeBlock
-                .builder()
-                .add(declare(GRAPH_CONTEXT_NAME, asMethodCall(VARIABLE_ENV, METHOD_GRAPH_CONTEXT)));
-        target.getService().getContextFields().forEach((name, type) -> code.add(declare("_" + name, asCast(type, CodeBlock.of("$N.get($S)", GRAPH_CONTEXT_NAME, name)))));
-        return code.build();
-    }
-
     /**
      * @return Code that both fetches record data and creates the appropriate response objects.
      */

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/fetch/FetchResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/fetch/FetchResolverMethodGenerator.java
@@ -45,6 +45,7 @@ public class FetchResolverMethodGenerator extends KickstartResolverMethodGenerat
         var parser = new InputParser(target, processedSchema);
         var methodCall = getMethodCall(target, parser, false); // Note, do this before declaring services.
         return spec
+                .addCode(declareContextArgs(target))
                 .addCode(transformInputs(target, parser))
                 .addCode(declareAllServiceClasses(target.getName()))
                 .addCode(methodCall)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/update/ServiceUpdateResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/update/ServiceUpdateResolverMethodGenerator.java
@@ -23,11 +23,6 @@ public class ServiceUpdateResolverMethodGenerator extends UpdateResolverMethodGe
         super(localField, processedSchema);
     }
 
-    @NotNull
-    private CodeBlock generateServiceCall(String methodName, String serviceObjectName) {
-        return CodeBlock.of("$N.$L($L)", serviceObjectName, methodName, parser.getInputParamString());
-    }
-
     /**
      * @return Code that both fetches record data and creates the appropriate response objects.
      */

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/update/UpdateResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/resolvers/kickstart/update/UpdateResolverMethodGenerator.java
@@ -33,17 +33,14 @@ public abstract class UpdateResolverMethodGenerator extends KickstartResolverMet
         specInputs.forEach(input -> spec.addParameter(iterableWrapType(input), input.getName()));
 
         var methodCall = getMethodCall(target, parser, true); // Must happen before service declaration checks the found dependencies.
-        var code = CodeBlock
-                .builder()
-                .add(transformInputs(specInputs, parser.hasRecords()))
-                .add(declareAllServiceClasses(target.getName()))
-                .add(methodCall)
-                .add("\n")
-                .add(generateSchemaOutputs(target));
-
         return spec
                 .addParameter(DATA_FETCHING_ENVIRONMENT.className, VARIABLE_ENV)
-                .addCode(code.build())
+                .addCode(declareContextArgs(target))
+                .addCode(transformInputs(specInputs, parser.hasRecords()))
+                .addCode(declareAllServiceClasses(target.getName()))
+                .addCode(methodCall)
+                .addCode("\n")
+                .addCode(generateSchemaOutputs(target))
                 .build();
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/resolvers/kickstart/services/fetch/ResolverTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/resolvers/kickstart/services/fetch/ResolverTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.CONTEXT_SERVICE;
 import static no.sikt.graphitron.common.configuration.ReferencedEntry.RESOLVER_FETCH_SERVICE;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.*;
 
@@ -24,7 +25,7 @@ public class ResolverTest extends GeneratorTest {
 
     @Override
     protected Set<ExternalReference> getExternalReferences() {
-        return makeReferences(RESOLVER_FETCH_SERVICE);
+        return makeReferences(RESOLVER_FETCH_SERVICE, CONTEXT_SERVICE);
     }
 
     @Override
@@ -47,6 +48,17 @@ public class ResolverTest extends GeneratorTest {
     @DisplayName("Basic root service with a parameter")
     void withInput() {
         assertGeneratedContentContains("operation/withInput", "query(String id,", "resolverFetchService.query(id)");
+    }
+
+    @Test
+    @DisplayName("Basic root service with a context parameter")
+    void withContextInput() {
+        assertGeneratedContentContains(
+                "operation/withContextInput",
+                "_graphCtx = env.getGraphQlContext()",
+                "_ctxField = ((String) _graphCtx.get(\"ctxField\"))",
+                "query(_ctxField)"
+        );
     }
 
     @Test

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/kickstart/fetch/services/operation/withContextInput/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/kickstart/fetch/services/operation/withContextInput/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  query: String @service(service: {name: "CONTEXT_SERVICE"}, contextArguments: "ctxField")
+}


### PR DESCRIPTION
Quick attempt to fix kickstart resolver compilation errors when using context. Adds few tests because this code should be deleted soon.