### PR TITLE
removes redundant declaration of directory "/graphitron-example" from…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,6 @@ updates:
       - "org.mockito*"
       - "com.approvaltests*"
 
-- package-ecosystem: "maven"
-  directory: "/graphitron-example/graphitron-example-server"
-  schedule:
-    interval: "weekly"
-
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
… dependabot.yml.

This redundancy caused creation of two dependabot PRs for the same dependency.

Example:
- https://github.com/sikt-no/graphitron/pull/72
- https://github.com/sikt-no/graphitron/pull/73