### PR TITLE
GG-223 keep primary key for multitable fields

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/ResolverKeyHelpers.java
@@ -69,7 +69,7 @@ public class ResolverKeyHelpers {
         String foreignKeyName;
         var primaryKeyOptional = getPrimaryKeyForTable(containerTypeTable.getName());
 
-        if (GeneratorConfig.alwaysUsePrimaryKeyInSplitQueries()) {
+        if (GeneratorConfig.alwaysUsePrimaryKeyInSplitQueries() || processedSchema.isMultiTableField(field)) {
             return primaryKeyOptional
                     .orElseThrow(() -> new IllegalArgumentException(
                             String.format("Code generation failed for %s.%s as the table %s must have a primary key in order to reference another table in %s field.",

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
@@ -211,4 +211,37 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
                 "this.addressesKey = primaryKey;"
         );
     }
+
+    @Test
+    @DisplayName("Field referencing multitable interface")
+    void referencingMultitableInterface() {
+        assertGeneratedContentContains("referencingMultitableInterface",
+                "FilmCategory(Record2<Long, Long> primaryKey)",
+                "this.titledFilmsKey = primaryKey;"
+        );
+    }
+
+    @Test
+    @DisplayName("Field referencing multitable interface connection")
+    void referencingMultitableInterfaceConnection() {
+        assertGeneratedContentContains("referencingMultitableInterfaceConnection",
+                "this.titledFilmsKey = primaryKey;"
+        );
+    }
+
+    @Test
+    @DisplayName("Field referencing multitable union")
+    void referencingMultitableUnion() {
+        assertGeneratedContentContains("referencingMultitableUnion",
+                "this.filmsKey = primaryKey;"
+        );
+    }
+
+    @Test
+    @DisplayName("Field referencing multitable interface union")
+    void referencingMultitableUnionConnection() {
+        assertGeneratedContentContains("referencingMultitableUnionConnection",
+                "this.filmsKey = primaryKey;"
+        );
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceInputTest.java
@@ -1,8 +1,13 @@
 package no.sikt.graphitron.queries.fetch;
 
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.InterfaceOnlyFetchDBClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
@@ -12,6 +17,11 @@ public class ReferenceInputTest extends ReferenceTest {
     @Override
     protected String getSubpath() {
         return super.getSubpath() + "/input";
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new MapOnlyFetchDBClassGenerator(schema), new InterfaceOnlyFetchDBClassGenerator(schema));
     }
 
     @Test

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
@@ -1,10 +1,15 @@
 package no.sikt.graphitron.queries.fetch;
 
 import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.InterfaceOnlyFetchDBClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.ReferencedEntry.REFERENCE_CUSTOMER_CONDITION;
@@ -94,6 +99,24 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
         assertGeneratedContentContains(
                 "previousQuerySingleTableInterface", Set.of(ADDRESS_BY_DISTRICT),
                 "row(DSL.row(_city.CITY_ID)).mapping"
+        );
+    }
+
+    @Test
+    @DisplayName("Primary key columns should be selected in previous query for field returning multitable interface")
+    void previousQueryMultitableInterface() {
+        assertGeneratedContentContains(
+                "previousQueryMultitableInterface",
+                "row(DSL.row(_filmcategory.FILM_ID, _filmcategory.CATEGORY_ID)).mapping"
+        );
+    }
+
+    @Test
+    @DisplayName("Primary key columns should be selected in previous query for field returning multitable union")
+    void previousQueryMultitableUnion() {
+        assertGeneratedContentContains(
+                "previousQueryMultitableUnion",
+                "row(DSL.row(_filmcategory.FILM_ID, _filmcategory.CATEGORY_ID)).mapping"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
@@ -1,15 +1,10 @@
 package no.sikt.graphitron.queries.fetch;
 
 import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
-import no.sikt.graphitron.generators.abstractions.ClassGenerator;
-import no.sikt.graphitron.reducedgenerators.InterfaceOnlyFetchDBClassGenerator;
-import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
-import no.sikt.graphql.schema.ProcessedSchema;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.ReferencedEntry.REFERENCE_CUSTOMER_CONDITION;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceTest.java
@@ -25,6 +25,6 @@ abstract public class ReferenceTest extends GeneratorTest {
 
     @Override
     protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
-        return List.of(new MapOnlyFetchDBClassGenerator(schema), new InterfaceOnlyFetchDBClassGenerator(schema));
+        return List.of(new MapOnlyFetchDBClassGenerator(schema));
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableInterface/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableInterface/schema.graphqls
@@ -1,0 +1,12 @@
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    titledFilms: [Titled] @splitQuery
+}
+
+type Film implements Titled @table {
+    id: ID!
+    title: String!
+}
+
+interface Titled {
+    title: String!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableInterfaceConnection/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableInterfaceConnection/schema.graphqls
@@ -1,0 +1,23 @@
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    titledFilms(first: Int = 100, after: String): TitledConnection
+}
+
+type Film implements Titled @table {
+    id: ID!
+    title: String!
+}
+
+interface Titled {
+    title: String!
+}
+
+type TitledConnection {
+    edges: [TitledConnectionEdge]
+    pageInfo: PageInfo
+    nodes: [Titled!]!
+}
+
+type TitledConnectionEdge {
+    cursor: String
+    node: Titled
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableUnion/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableUnion/schema.graphqls
@@ -1,0 +1,9 @@
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    films: [FilmUnion] @splitQuery
+}
+
+union FilmUnion = Film
+
+type Film @table {
+    id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableUnionConnection/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/referencingMultitableUnionConnection/schema.graphqls
@@ -1,0 +1,21 @@
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    films(first: Int = 100, after: String): FilmUnionConnection
+}
+
+union FilmUnion = Film
+
+type Film @table {
+    id: ID!
+}
+
+
+type FilmUnionConnection {
+    edges: [FilmUnionConnectionEdge]
+    pageInfo: PageInfo
+    nodes: [FilmUnion!]!
+}
+
+type FilmUnionConnectionEdge {
+    cursor: String
+    node: FilmUnion
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQueryMultitableInterface/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQueryMultitableInterface/schema.graphqls
@@ -1,0 +1,16 @@
+type Query {
+    query: FilmCategory
+}
+
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    titledFilms: [Titled] @splitQuery
+}
+
+type Film implements Titled @table {
+    id: ID!
+    title: String!
+}
+
+interface Titled {
+    title: String!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQueryMultitableUnion/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/previousQueryMultitableUnion/schema.graphqls
@@ -1,0 +1,13 @@
+type Query {
+    query: FilmCategory
+}
+
+type FilmCategory @table(name: "FILM_CATEGORY") {
+    films: [FilmUnion] @splitQuery
+}
+
+union FilmUnion = Film
+
+type Film @table {
+    id: ID!
+}


### PR DESCRIPTION
Expand DTOs and queries to keep primary key of previous object on multitable(unions and interfaces) splitQuery fields