### PR TITLE
GG-227 Store resolver keys as Row instead of Record

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -919,11 +919,7 @@ public class FormatCodeBlocks {
     }
 
     public static CodeBlock inResolverKeysBlock(String resolverKeyParamName, FetchContext context) {
-        return CodeBlock.of("$L.in($N.stream().map($T::valuesRow).toList())",
-                getSelectKeyColumnRow(context),
-                resolverKeyParamName,
-                context.getResolverKey().getTypeName(false)
-        );
+        return CodeBlock.of("$L.in($N)", getSelectKeyColumnRow(context), resolverKeyParamName);
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/KeyWrapper.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/KeyWrapper.java
@@ -29,26 +29,39 @@ public record KeyWrapper(Key<?> key) {
     }
 
     /**
-     * Get the TypeName for the key variable
+     * Get the Row TypeName for the key variable
      *
-     * @return TypeName of the key variable
+     * @return Row TypeName of the key variable
      */
-    public TypeName getTypeName() {
-        return getTypeName(true);
+    public TypeName getRowTypeName() {
+        return getTypeName(true, false);
     }
 
     /**
-     * Get the TypeName for the key variable
+     * Get the Record TypeName for the key variable
      *
-     * @return TypeName of the key variable
+     * @return Record TypeName of the key variable
      */
-    public TypeName getTypeName(boolean parameterized) {
+    public TypeName getRecordTypeName() {
+        return getRecordTypeName(true);
+    }
+
+    /**
+     * Get the Record TypeName for the key variable
+     *
+     * @return Record TypeName of the key variable
+     */
+    public TypeName getRecordTypeName(boolean parameterized) {
+        return getTypeName(parameterized, true);
+    }
+
+    private TypeName getTypeName(boolean parameterized, boolean asRecordType) {
         var keyFields = key.getFields();
 
         if (keyFields.size() > 22) {
             throw new RuntimeException(String.format("Key '%s' has more than 22 fields, which is not supported.", key.getName()));
         }
-        var recordClassName = ClassName.get("org.jooq", String.format("Record%d", keyFields.size()));
+        var recordClassName = ClassName.get("org.jooq", String.format("%s%d", asRecordType ? "Record" : "Row", keyFields.size()));
         return parameterized ?
                 ParameterizedTypeName.get(
                         recordClassName,
@@ -153,12 +166,12 @@ public record KeyWrapper(Key<?> key) {
     }
 
     /**
-     * Get the TypeName for the key used for a resolver field
+     * Get the Record TypeName for the key used for a resolver field
      *
      * @param field The resolver field
      * @return TypeName of the key variable
      */
-    public static TypeName getKeyTypeName(GenerationField field, ProcessedSchema schema) {
-        return findKeyForResolverField(field, schema).getTypeName();
+    public static TypeName getKeyRecordTypeName(GenerationField field, ProcessedSchema schema) {
+        return findKeyForResolverField(field, schema).getRowTypeName();
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchCountDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchCountDBMethodGenerator.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.declare;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.asCountMethodName;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.asInternalName;
-import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeyTypeName;
+import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeyRecordTypeName;
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.wrapSet;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.DSL;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.INTEGER;
@@ -119,7 +119,7 @@ public class FetchCountDBMethodGenerator extends FetchDBMethodGenerator {
         );
 
         if (!isRoot) {
-            spec.addParameter(wrapSet(getKeyTypeName(referenceField, processedSchema)), resolverKeyParamName);
+            spec.addParameter(wrapSet(getKeyRecordTypeName(referenceField, processedSchema)), resolverKeyParamName);
         }
 
         parser.getMethodInputs().forEach((key, value) -> spec.addParameter(iterableWrapType(value), key));

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 import static no.sikt.graphitron.configuration.GeneratorConfig.useOptionalSelects;
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.*;
 import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeySetForResolverFields;
-import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeyTypeName;
+import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeyRecordTypeName;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.*;
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.*;
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
@@ -406,7 +406,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
 
         int i = 0;
         for (var key : keySet) {
-            innerMappingCode.add(CodeBlock.of("($T) r[$L]", key.getTypeName(), i));
+            innerMappingCode.add(CodeBlock.of("($T) r[$L]", key.getRecordTypeName(), i));
             i++;
         }
 
@@ -971,7 +971,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 getReturnType(referenceField, refTypeName)
         );
         if (!isRoot) {
-            spec.addParameter(wrapSet(getKeyTypeName(referenceField, processedSchema)), resolverKeyParamName);
+            spec.addParameter(wrapSet(getKeyRecordTypeName(referenceField, processedSchema)), resolverKeyParamName);
         }
 
         parser.getMethodInputsWithOrderField().forEach((key, value) -> spec.addParameter(iterableWrapType(value), key));
@@ -998,7 +998,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         if (isRoot && !lookupExists) {
             return wrapListIf(type, referenceField.isIterableWrapped() || referenceField.hasForwardPagination());
         } else if (!isRoot) {
-            return wrapMap(getKeyTypeName(referenceField, processedSchema), wrapListIf(type, referenceField.isIterableWrapped() && !lookupExists || referenceField.hasForwardPagination()));
+            return wrapMap(getKeyRecordTypeName(referenceField, processedSchema), wrapListIf(type, referenceField.isIterableWrapped() && !lookupExists || referenceField.hasForwardPagination()));
         } else {
             return wrapMap(STRING.className, wrapListIf(type, referenceField.hasForwardPagination()));
         }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMappedObjectDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMappedObjectDBMethodGenerator.java
@@ -146,7 +146,11 @@ public class FetchMappedObjectDBMethodGenerator extends FetchDBMethodGenerator {
                     .build();
         }
 
-        var code = CodeBlock.builder().add(".fetchMap($T::value1, ", RECORD2.className);
+        var code = CodeBlock.builder()
+                .add(".fetchMap(")
+                .addIf(lookupExists, "$T::value1, ", RECORD2.className)
+                .addIf(!lookupExists, "r -> r.value1().valuesRow(), ");
+
         if (referenceField.isIterableWrapped() && !lookupExists || referenceField.hasForwardPagination()) {
             if (referenceField.hasForwardPagination() && (referenceField.getOrderField().isPresent() || tableHasPrimaryKey(refObject.getTable().getName()))) {
                 return code.addStatement("r -> r.value2().map($T::value2))", RECORD2.className).build();
@@ -168,7 +172,7 @@ public class FetchMappedObjectDBMethodGenerator extends FetchDBMethodGenerator {
             code
                     .add(".fetchMap(\n")
                     .indent()
-                    .add("$T::value1,\n", RECORD2.className)
+                    .add("r -> r.value1().valuesRow(),\n")
                     .add("it ->  it.value2().map(r -> r.value2() == null ? null : new $T<>(r.value1(), r.value2()))", IMMUTABLE_PAIR.className)
                     .unindent()
                     .addStatement(")");

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/InterfaceDTOGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/InterfaceDTOGenerator.java
@@ -30,7 +30,7 @@ public class InterfaceDTOGenerator extends DTOGenerator {
                 .forEach(( key) -> {
                     interfaceBuilder.addMethod(
                             MethodSpec.methodBuilder("get" + capitalize(key.key() instanceof UniqueKey ? PRIMARY_KEY : key.key().getName()))
-                                    .returns(key.getTypeName())
+                                    .returns(key.getRowTypeName())
                                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                                     .build()
                     );

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryOnlyPrimaryKeyTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryOnlyPrimaryKeyTest.java
@@ -36,7 +36,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     void scalarReference() {
         assertGeneratedContentContains("scalarReference",
                 "VacationDestination(Record2<Long, String> primaryKey)",
-                "this.vacationDescriptionKey = primaryKey;"
+                "this.vacationDescriptionKey = primaryKey"
                 );
     }
 
@@ -44,7 +44,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Field with splitQuery referencing another table should store primary key fields")
     void reference() {
         assertGeneratedContentContains("reference",
-                "Record2<Long, String> primaryKey",
+                "Row2<Long, String> primaryKey",
                 "VacationDestination(Record2<Long, String> primaryKey)",
                 "this.vacationKey = primaryKey"
         );
@@ -54,7 +54,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Listed field should keep primary key fields")
     void listedReference() {
         assertGeneratedContentContains("listedReference",
-                "Record1<Long> destinationKey",
+                "Row1<Long> destinationKey",
                 "Vacation(Record1<Long> primaryKey)",
                 "this.destinationKey = primaryKey"
         );
@@ -64,7 +64,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Fields with reverse reference should keep primary key fields even if they are not listed")
     void reverseReference() {
         assertGeneratedContentContains("reverseReference",
-                "Record1<Long> destinationKey",
+                "Row1<Long> destinationKey",
                 "Vacation(Record1<Long> primaryKey)",
                 "this.destinationKey = primaryKey"
         );
@@ -84,8 +84,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     void conditionPath() {
         assertGeneratedContentContains("conditionPath",
                 "VacationDestination(Record2<Long, String> primaryKey) " +
-                        "{ this.primaryKey = primaryKey; this.someStringsKey = primaryKey; }",
-                "private Record2<Long, String> someStringsKey"
+                        "{ this.primaryKey = primaryKey.valuesRow(); this.someStringsKey = primaryKey.valuesRow(); }",
+                "private Row2<Long, String> someStringsKey"
         );
     }
 
@@ -136,8 +136,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Field with self reference should store primary key fields")
     void selfReference() {
         assertGeneratedContentContains("selfReference",
-                "Record1<Long> sequelKey",
-                "this.sequelKey = primaryKey;"
+                "Row1<Long> sequelKey",
+                "this.sequelKey = primaryKey"
         );
     }
 
@@ -145,7 +145,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void interfaceWithTable() {
         assertGeneratedContentContains("interfaceWithTable",
-                "Record2<Long, String> getSomeStringKey()"
+                "Row2<Long, String> getSomeStringKey()"
         );
     }
 
@@ -153,8 +153,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void conditionPathFromInterfaceWithTable() {
         assertGeneratedContentContains("conditionPathFromInterfaceWithTable",
-                "Record2<Long, String> getPrimaryKey()",
-                "Record2<Long, String> getSomeStringKey()"
+                "Row2<Long, String> getPrimaryKey()",
+                "Row2<Long, String> getSomeStringKey()"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
@@ -48,9 +48,9 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field with splitQuery referencing another table should store foreign key fields")
     void reference() {
         assertGeneratedContentContains("reference",
-                "Record1<Long> vacationKey",
+                "Row1<Long> vacationKey",
                 "VacationDestination(Record1<Long> vacation_destination_vacation_fkey)",
-                "this.vacationKey = vacation_destination_vacation_fkey"
+                "this.vacationKey = vacation_destination_vacation_fkey.valuesRow()"
         );
     }
 
@@ -58,7 +58,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Listed field should keep primary key fields")
     void listedReference() {
         assertGeneratedContentContains("listedReference",
-                "Record1<Long> destinationKey",
+                "Row1<Long> destinationKey",
                 "Vacation(Record1<Long> primaryKey)",
                 "this.destinationKey = primaryKey"
         );
@@ -68,7 +68,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Fields with reverse reference should keep primary key fields even if they are not listed")
     void reverseReference() {
         assertGeneratedContentContains("reverseReference",
-                "Record1<Long> destinationKey",
+                "Row1<Long> destinationKey",
                 "Vacation(Record1<Long> primaryKey)",
                 "this.destinationKey = primaryKey"
         );
@@ -88,8 +88,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void conditionPath() {
         assertGeneratedContentContains("conditionPath",
                 "VacationDestination(Record2<Long, String> primaryKey) " +
-                        "{ this.primaryKey = primaryKey; this.someStringsKey = primaryKey; }",
-                "private Record2<Long, String> someStringsKey"
+                        "{ this.primaryKey = primaryKey.valuesRow(); this.someStringsKey = primaryKey.valuesRow(); }",
+                "private Row2<Long, String> someStringsKey"
         );
     }
 
@@ -140,8 +140,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field with self reference should store foreign key fields")
     void selfReference() {
         assertGeneratedContentContains("selfReference",
-                "Record1<Long> sequelKey",
-                "this.sequel_fkey = sequel_fkey; this.sequelKey = sequel_fkey;"
+                "Row1<Long> sequelKey",
+                "this.sequel_fkey = sequel_fkey.valuesRow(); this.sequelKey = sequel_fkey.valuesRow();"
         );
     }
 
@@ -149,7 +149,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void interfaceWithTable() {
         assertGeneratedContentContains("interfaceWithTable",
-                "Record1<Long> getSomeStringKey()"
+                "Row1<Long> getSomeStringKey()"
         );
     }
 
@@ -157,8 +157,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void conditionPathFromInterfaceWithTable() {
         assertGeneratedContentContains("conditionPathFromInterfaceWithTable",
-                "Record2<Long, String> getPrimaryKey()",
-                "Record2<Long, String> getSomeStringKey()"
+                "Row2<Long, String> getPrimaryKey()",
+                "Row2<Long, String> getSomeStringKey()"
         );
     }
 
@@ -199,7 +199,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void referencingSingleTableInterface() {
         assertGeneratedContentContains("referencingSingleTableInterface", Set.of(ADDRESS_BY_DISTRICT),
                 "City(Record1<Long> primaryKey)",
-                "this.addressesKey = primaryKey;"
+                "this.addressesKey = primaryKey"
         );
     }
 
@@ -208,7 +208,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void referencingSingleTableInterfaceConnection() {
         assertGeneratedContentContains("referencingSingleTableInterfaceConnection", Set.of(ADDRESS_BY_DISTRICT, ADDRESS_BY_DISTRICT_CONNECTION),
                 "City(Record1<Long> primaryKey)",
-                "this.addressesKey = primaryKey;"
+                "this.addressesKey = primaryKey"
         );
     }
 
@@ -217,7 +217,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void referencingMultitableInterface() {
         assertGeneratedContentContains("referencingMultitableInterface",
                 "FilmCategory(Record2<Long, Long> primaryKey)",
-                "this.titledFilmsKey = primaryKey;"
+                "this.titledFilmsKey = primaryKey"
         );
     }
 
@@ -225,7 +225,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable interface connection")
     void referencingMultitableInterfaceConnection() {
         assertGeneratedContentContains("referencingMultitableInterfaceConnection",
-                "this.titledFilmsKey = primaryKey;"
+                "this.titledFilmsKey = primaryKey"
         );
     }
 
@@ -233,7 +233,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable union")
     void referencingMultitableUnion() {
         assertGeneratedContentContains("referencingMultitableUnion",
-                "this.filmsKey = primaryKey;"
+                "this.filmsKey = primaryKey"
         );
     }
 
@@ -241,7 +241,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable interface union")
     void referencingMultitableUnionConnection() {
         assertGeneratedContentContains("referencingMultitableUnionConnection",
-                "this.filmsKey = primaryKey;"
+                "this.filmsKey = primaryKey"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/InputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/InputTest.java
@@ -174,7 +174,7 @@ public class InputTest extends GeneratorTest {
     void onSplitQueryField() {
         assertGeneratedContentContains("onSplitQueryField",
                 ".from(address_2030472956_customer).where(address_2030472956_customer.EMAIL.eq(email))",
-                ".from(_address).where(DSL.row(_address.ADDRESS_ID).in(addressResolverKeys.stream().map(Record1::valuesRow).toList())).fetch" // Make sure conditon is not applied on outer query
+                ".from(_address).where(DSL.row(_address.ADDRESS_ID).in(addressResolverKeys)).fetch" // Make sure conditon is not applied on outer query
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/OutputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/OutputTest.java
@@ -46,11 +46,11 @@ public class OutputTest extends GeneratorTest {
     void splitQuery() {
         assertGeneratedContentContains(
                 "splitQuery", Set.of(CUSTOMER_TABLE, SPLIT_QUERY_WRAPPER),
-                "Map<Record1<Long>, CustomerTable> queryForWrapper",
-                "Set<Record1<Long>> wrapperResolverKeys",
+                "Map<Row1<Long>, CustomerTable> queryForWrapper",
+                "Set<Row1<Long>> wrapperResolverKeys",
                 ".select(DSL.row(_address.ADDRESS_ID),DSL.field(",
-                ".where(DSL.row(_address.ADDRESS_ID).in(wrapperResolverKeys.stream().map(Record1::valuesRow).toList()))",
-                ".fetchMap(Record2::value1, Record2::value2"
+                ".where(DSL.row(_address.ADDRESS_ID).in(wrapperResolverKeys))",
+                ".fetchMap(r -> r.value1().valuesRow(), Record2::value2"
         );
     }
 
@@ -59,9 +59,9 @@ public class OutputTest extends GeneratorTest {
     void splitQueryListed() {
         assertGeneratedContentContains(
                 "splitQueryListed", Set.of(CUSTOMER_TABLE, SPLIT_QUERY_WRAPPER),
-                "Map<Record1<Long>, List<CustomerTable>> queryForWrapper",
+                "Map<Row1<Long>, List<CustomerTable>> queryForWrapper",
                 ".select(DSL.row(_address.ADDRESS_ID),DSL.multiset(DSL.select",
-                ".fetchMap(Record2::value1, r -> r.value2().map(Record1::value1))"
+                ".fetchMap(r -> r.value1().valuesRow(), r -> r.value2().map(Record1::value1))"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceAliasTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceAliasTest.java
@@ -76,7 +76,7 @@ public class ReferenceAliasTest extends ReferenceTest {
                 "_customer.address().as(",
                 "DSL.row(customer_2952383337_address.getId()",
                 ".from(_customer",
-                ".where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys.stream().map(Record1::valuesRow).toList()))"
+                ".where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys))"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
@@ -199,7 +199,7 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
                 "customer_2952383337_address = _customer.address().as(", // Note, implicit join is present when we use a key, but not table.
                 ".from(customer_2952383337_address).where(",
                 ".addressCustomer(_customer, customer_2952383337_address)", // Note, no condition override unlike table case.
-                ".where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys.stream"
+                ".where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys"
         );
     }
 
@@ -250,7 +250,7 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
                 "list", Set.of(CUSTOMER_NOT_GENERATED),
                 ".from(customer_2952383337_address)",
                 "DSL.multiset(DSL.select(",
-                ".fetchMap(Record2::value1, r -> r.value2().map(Record1::value1))"
+                ".fetchMap(r -> r.value1().valuesRow(), r -> r.value2().map(Record1::value1))"
         );
     }
 
@@ -304,7 +304,7 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
                 "fromMultitableInterface", Set.of(CUSTOMER_TABLE),
                 "DSL.row(_payment.PAYMENT_ID), DSL.field(",
                 "CustomerTable::new))).from(payment_425747824_customer)",
-                ".from(_payment).where(DSL.row(_payment.PAYMENT_ID).in(paymentResolverKeys.stream()"
+                ".from(_payment).where(DSL.row(_payment.PAYMENT_ID).in(paymentResolverKeys"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/scalarReference/expected/VacationDestination.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/scalarReference/expected/VacationDestination.java
@@ -6,27 +6,32 @@ import java.lang.Object;
 import java.lang.Override;
 import java.util.Objects;
 import org.jooq.Record1;
+import org.jooq.Row1;
 
 public class VacationDestination implements Serializable {
 
-    private Record1<Long> vacation_destination_vacation_fkey;
+    private Row1<Long> vacation_destination_vacation_fkey;
 
-    private Record1<Long> vacationDescriptionKey;
+    private Row1<Long> vacationDescriptionKey;
 
     public VacationDestination() {
     }
 
     public VacationDestination(Record1<Long> vacation_destination_vacation_fkey) {
-        this.vacation_destination_vacation_fkey = vacation_destination_vacation_fkey;
-        this.vacationDescriptionKey = vacation_destination_vacation_fkey;
+        this.vacation_destination_vacation_fkey = vacation_destination_vacation_fkey.valuesRow();
+        this.vacationDescriptionKey = vacation_destination_vacation_fkey.valuesRow();
     }
 
-    public Record1<Long> getVacation_destination_vacation_fkey() {
+    public Row1<Long> getVacation_destination_vacation_fkey() {
         return vacation_destination_vacation_fkey;
     }
 
-    public Record1<Long> getVacationDescriptionKey() {
+    public Row1<Long> getVacationDescriptionKey() {
         return vacationDescriptionKey;
+    }
+
+    public void setVacationDescriptionKey(Row1<Long> vacationDescriptionKey) {
+        this.vacationDescriptionKey = vacationDescriptionKey;
     }
 
     @Override

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/splitQueryOnlyPrimaryKey/expected/CustomerDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/splitQueryOnlyPrimaryKey/expected/CustomerDBQueries.java
@@ -10,14 +10,14 @@ import no.sikt.graphql.NodeIdStrategy;
 import no.sikt.graphql.helpers.selection.SelectionSet;
 import org.jooq.DSLContext;
 import org.jooq.Functions;
-import org.jooq.Record1;
+import org.jooq.Row1;
 import org.jooq.Record2;
 import org.jooq.impl.DSL;
 
 
 public class CustomerDBQueries {
-    public static Map<Record1<Long>, Address> addressForCustomer(DSLContext ctx, NodeIdStrategy nodeIdStrategy,
-                                                          Set<Record1<Long>> customerResolverKeys, SelectionSet select) {
+    public static Map<Row1<Long>, Address> addressForCustomer(DSLContext ctx, NodeIdStrategy nodeIdStrategy,
+                                                          Set<Row1<Long>> customerResolverKeys, SelectionSet select) {
         var _customer = CUSTOMER.as("customer_2952383337");
         var customer_2952383337_address = _customer.address().as("address_1214171484");
         var orderFields = customer_2952383337_address.fields(customer_2952383337_address.getPrimaryKey().getFieldsArray());
@@ -30,7 +30,7 @@ public class CustomerDBQueries {
                         )
                 )
                 .from(_customer)
-                .where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys.stream().map(Record1::valuesRow).toList()))
-                .fetchMap(Record2::value1, Record2::value2);
+                .where(DSL.row(_customer.CUSTOMER_ID).in(customerResolverKeys))
+                .fetchMap(r -> r.value1().valuesRow(), Record2::value2);
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/pagination/splitQuery/expected/WrapperDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/pagination/splitQuery/expected/WrapperDBQueries.java
@@ -16,13 +16,12 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jooq.DSLContext;
 import org.jooq.Functions;
-import org.jooq.Record1;
-import org.jooq.Record2;
+import org.jooq.Row1;
 import org.jooq.impl.DSL;
 
 public class WrapperDBQueries {
-    public static Map<Record1<Long>, List<Pair<String, CustomerTable>>> queryForWrapper(DSLContext ctx,
-                                                                                 Set<Record1<Long>> wrapperResolverKeys, Integer pageSize, String after, SelectionSet select) {
+    public static Map<Row1<Long>, List<Pair<String, CustomerTable>>> queryForWrapper(DSLContext ctx,
+                                                                                 Set<Row1<Long>> wrapperResolverKeys, Integer pageSize, String after, SelectionSet select) {
         var _address = ADDRESS.as("address_2030472956");
         var address_2030472956_customer = _address.customer().as("customer_2337142794");
         var orderFields = address_2030472956_customer.fields(address_2030472956_customer.getPrimaryKey().getFieldsArray());
@@ -40,9 +39,9 @@ public class WrapperDBQueries {
                         )
                 )
                 .from(_address)
-                .where(DSL.row(_address.ADDRESS_ID).in(wrapperResolverKeys.stream().map(Record1::valuesRow).toList()))
+                .where(DSL.row(_address.ADDRESS_ID).in(wrapperResolverKeys))
                 .fetchMap(
-                        Record2::value1,
+                        r -> r.value1().valuesRow(),
                         it ->  it.value2().map(r -> r.value2() == null ? null : new ImmutablePair<>(r.value1(), r.value2()))
                 );
     }


### PR DESCRIPTION
The DTO now stores resolver keys as `Row` instead of `Record`. 

In order to fetch `splitQuery` field after a service, the resolver key must be set in the DTO during the mapping from jOOQ/java record to DTO.  `Record` cannot be instantiated, but  `Row` can be easily created with `DSL.row()`, so this change should enable us to solve GG-227.