### PR TITLE
GG-54 Fix hasId comparisons.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/helpers/InputCondition.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/helpers/InputCondition.java
@@ -10,7 +10,7 @@ import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 
 public class InputCondition {
-    private final InputField input;
+    private final InputField input, sourceInput;
     private final String namePath, startName;
     private final LinkedHashSet<String> nullChecks;
     private final boolean pastWasIterable, hasRecord;
@@ -18,6 +18,7 @@ public class InputCondition {
 
     private InputCondition(
             InputField input,
+            InputField sourceInput,
             String startName,
             String namePath,
             LinkedHashSet<String> nullChecks,
@@ -26,6 +27,7 @@ public class InputCondition {
             Boolean isOverriddenByAncestors,
             Boolean isWrappedInList) {
         this.input = input;
+        this.sourceInput = sourceInput;
         this.startName = startName;
         this.namePath = namePath;
         this.nullChecks = new LinkedHashSet<>(nullChecks);
@@ -38,15 +40,19 @@ public class InputCondition {
     }
 
     public InputCondition(InputField input, String startName, boolean hasRecord, Boolean isOverriddenByAncestors) {
-        this(input, startName, "", new LinkedHashSet<>(), false, hasRecord, isOverriddenByAncestors, false);
+        this(input, input, startName, "", new LinkedHashSet<>(), false, hasRecord, isOverriddenByAncestors, false);
     }
 
     public InputCondition(InputField input, boolean hasRecord) {
-        this(input, "", "",  new LinkedHashSet<>(), false, hasRecord, false, false);
+        this(input, input, "", "",  new LinkedHashSet<>(), false, hasRecord, false, false);
     }
 
     public InputField getInput() {
         return input;
+    }
+
+    public InputField getSourceInput() {
+        return sourceInput;
     }
 
     private void inferAdditionalChecks(InputField input) {
@@ -69,10 +75,15 @@ public class InputCondition {
     }
 
     public String getNameWithPathString() {
-        return namePath.isEmpty()
-                ? uncapitalize(startName.isEmpty() ? input.getName() : startName)
-                : (namePath + (hasRecord ? input.getMappingForRecordFieldOverride().asGetCall()
-                                         : input.getMappingFromSchemaName().asGetCall()).toString());
+        if (namePath.isEmpty()) {
+            return uncapitalize(startName.isEmpty() ? input.getName() : startName);
+        }
+
+        return namePath + (
+                hasRecord
+                        ? input.getMappingForRecordFieldOverride().asGetCall()
+                        : input.getMappingFromSchemaName().asGetCall()
+        ).toString();
     }
 
     public Boolean isOverriddenByAncestors() {
@@ -90,6 +101,7 @@ public class InputCondition {
     public InputCondition iterate(InputField input) {
         return new InputCondition(
                 input,
+                sourceInput,
                 startName,
                 getNameWithPathString(),
                 nullChecks,
@@ -102,6 +114,7 @@ public class InputCondition {
     public InputCondition applyTo(InputField input) {
         return new InputCondition(
                 input,
+                sourceInput,
                 startName,
                 namePath,
                 nullChecks,

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/OptionalInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/OptionalInputTest.java
@@ -68,11 +68,11 @@ public class OptionalInputTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "listedNestedInput", Set.of(DUMMY_INPUT),
                 "in0 != null && in0.size() > 0 ?" +
-                        "        DSL.row(_customer.getId()).in(" +
-                        "            in0.stream().map(internal_it_ ->" +
-                        "                DSL.row(DSL.inline(internal_it_.getIn1().getId()))" +
-                        "            ).toList()" +
-                        "        ) : DSL.noCondition())"
+                        "DSL.row(DSL.trueCondition()).in(" +
+                        "    in0.stream().map(internal_it_ ->" +
+                        "        DSL.row(_customer.hasId(internal_it_.getIn1().getId()))" +
+                        "    ).toList()" +
+                        ") : DSL.noCondition())"
         );
     }
 
@@ -82,11 +82,11 @@ public class OptionalInputTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "nestedListedInput", Set.of(DUMMY_INPUT),
                 "in != null && in.getIn() != null && in.getIn().size() > 0 ?" +
-                        "        DSL.row(_customer.getId()).in(" +
-                        "            in.getIn().stream().map(internal_it_ ->" +
-                        "                DSL.row(DSL.inline(internal_it_.getId()))" +
-                        "            ).toList()" +
-                        "        ) : DSL.noCondition())"
+                        "DSL.row(DSL.trueCondition()).in(" +
+                        "    in.getIn().stream().map(internal_it_ ->" +
+                        "        DSL.row(_customer.hasId(internal_it_.getId()))" +
+                        "    ).toList()" +
+                        ") : DSL.noCondition())"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/RecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/RecordTest.java
@@ -55,8 +55,8 @@ public class RecordTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "listedInputJavaRecord",
                 "customerForQuery(DSLContext ctx, List<DummyRecord> inRecordList,",
-                "DSL.row(_customer.getId(), _customer.getId()).in(" +
-                        "inRecordList.stream().map(internal_it_ -> DSL.row(DSL.inline(internal_it_.getId()), DSL.inline(internal_it_.getOtherID()))).toList()" +
+                "DSL.row(DSL.trueCondition(), DSL.trueCondition()).in(" +
+                        "inRecordList.stream().map(internal_it_ -> DSL.row(_customer.hasId(internal_it_.getId()), _customer.hasId(internal_it_.getOtherID()))).toList()" +
                         ") : DSL.noCondition()"
         );
     }
@@ -78,8 +78,8 @@ public class RecordTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "listedInputJOOQRecord",
                 "customerForQuery(DSLContext ctx, List<CustomerRecord> inRecordList,",
-                "DSL.row(_customer.getId(), _customer.FIRST_NAME).in(" +
-                        "inRecordList.stream().map(internal_it_ -> DSL.row(DSL.inline(internal_it_.getId()), DSL.inline(internal_it_.getFirstName()))).toList()" +
+                "DSL.row(DSL.trueCondition(), _customer.FIRST_NAME).in(" +
+                        "inRecordList.stream().map(internal_it_ -> DSL.row(_customer.hasId(internal_it_.getId()), DSL.inline(internal_it_.getFirstName()))).toList()" +
                         ") : DSL.noCondition()"
         );
     }
@@ -93,7 +93,7 @@ public class RecordTest extends GeneratorTest {
     @Test // Not sure if this is allowed.
     @DisplayName("Input type with an ID field annotated with @field without @nodeId")
     void fieldOverrideID() {
-        assertGeneratedContentContains("fieldOverrideID", "_payment.getCustomerId()", "_payment.getPaymentId()");
+        assertGeneratedContentContains("fieldOverrideID", "_payment.hasCustomerId(internal_it_.getCustomerId())", "_payment.hasPaymentId(internal_it_.getPaymentId())");
     }
 
     @Test // In these cases the table must be selected based on the input record, otherwise this is not resolvable.

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withInputJOOQRecordAndCondition/expected/QueryDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withInputJOOQRecordAndCondition/expected/QueryDBQueries.java
@@ -35,13 +35,13 @@ public class QueryDBQueries {
                 .where(
                         inRecordList != null && inRecordList.size() > 0 ?
                                 DSL.row(
-                                        _customer.getId(),
+                                        DSL.trueCondition(),
                                         _customer.FIRST_NAME,
                                         DSL.trueCondition()
                                 ).in(
                                         inRecordList.stream().map(internal_it_ ->
                                                 DSL.row(
-                                                        DSL.inline(internal_it_.getId()),
+                                                        _customer.hasId(internal_it_.getId()),
                                                         DSL.inline(internal_it_.getFirstName()),
                                                         no.sikt.graphitron.codereferences.conditions.RecordCustomerCondition.customerString(_customer, internal_it_.getFirstName())
                                                 )

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withInputJavaRecordAndCondition/expected/QueryDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withInputJavaRecordAndCondition/expected/QueryDBQueries.java
@@ -35,13 +35,13 @@ public class QueryDBQueries {
                 .where(
                         inRecordList != null && inRecordList.size() > 0 ?
                                 DSL.row(
-                                        _customer.getId(),
+                                        DSL.trueCondition(),
                                         _customer.FIRST,
                                         DSL.trueCondition()
                                 ).in(
                                         inRecordList.stream().map(internal_it_ ->
                                                 DSL.row(
-                                                        DSL.inline(internal_it_.getId()),
+                                                        _customer.hasId(internal_it_.getId()),
                                                         DSL.inline(internal_it_.getFirst()),
                                                         no.sikt.graphitron.codereferences.conditions.RecordCustomerCondition.customerString(_customer, internal_it_.getFirst())
                                                 )

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withListedInputConditions/expected/QueryDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/records/withListedInputConditions/expected/QueryDBQueries.java
@@ -22,13 +22,13 @@ public class QueryDBQueries {
                 .where(
                         inRecordList != null && inRecordList.size() > 0 ?
                                 DSL.row(
-                                        _customer.getId(),
+                                        DSL.trueCondition(),
                                         DSL.trueCondition(),
                                         DSL.trueCondition()
                                 ).in(
                                         inRecordList.stream().map(internal_it_ ->
                                                 DSL.row(
-                                                        DSL.inline(internal_it_.getId()),
+                                                        _customer.hasId(internal_it_.getId()),
                                                         no.sikt.graphitron.codereferences.conditions.RecordCustomerCondition.customerString(_customer, internal_it_.getId()),
                                                         no.sikt.graphitron.codereferences.conditions.RecordCustomerCondition.customerString(_customer, internal_it_.getFirstName())
                                                 )


### PR DESCRIPTION
Fix the failing ID comparisons (for cases without nodeId-directives). Only relevant for datafetchers, kickstart still uses the old resolvers.