### PR TITLE
prevents implementing Serializable on generated DTO classes

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/JoinListSequence.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/JoinListSequence.java
@@ -3,6 +3,7 @@ package no.sikt.graphitron.generators.context;
 import no.sikt.graphitron.definitions.interfaces.JoinElement;
 import no.sikt.graphitron.javapoet.CodeBlock;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,6 +16,8 @@ import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.asMeth
  * A list of table or key references.
  */
 public class JoinListSequence extends LinkedList<JoinElement> {
+    @Serial
+    private static final long serialVersionUID = 1L;
     /**
      * @return Render all the elements of this list to a method call sequence.
      */

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
@@ -9,7 +9,6 @@ import no.sikt.graphql.schema.ProcessedSchema;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.lang.model.element.Modifier;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,8 +32,6 @@ public abstract class DTOGenerator extends AbstractClassGenerator {
         var classBuilder = TypeSpec.classBuilder(targetName)
                 .addModifiers(Modifier.PUBLIC)
                 .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build());
-
-        classBuilder.addSuperinterface(ClassName.get(Serializable.class));
 
         var constructorBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
@@ -55,7 +55,7 @@ public class TypeDTOGeneratorTest extends DTOGeneratorTest {
     @DisplayName("Type implementing interface")
     void implementingInterface() {
         assertGeneratedContentContains("implementingInterface", Set.of(VALIDATION_ERROR),
-                "ValidationError implements Serializable, Error"
+                "ValidationError implements Error"
         );
     }
 
@@ -63,7 +63,7 @@ public class TypeDTOGeneratorTest extends DTOGeneratorTest {
     @DisplayName("Type is part of a union")
     void isPartOfUnion() {
         assertGeneratedContentContains("isPartOfUnion", Set.of(CUSTOMER_TABLE),
-                "CustomerTable implements Serializable, SomeUnion");
+                "CustomerTable implements SomeUnion");
     }
 
     @Test

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/scalarReference/expected/VacationDestination.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/scalarReference/expected/VacationDestination.java
@@ -1,6 +1,5 @@
 package no.sikt.graphitron.example.generated.graphitron.model;
 
-import java.io.Serializable;
 import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
@@ -8,8 +7,7 @@ import java.util.Objects;
 import org.jooq.Record1;
 import org.jooq.Row1;
 
-public class VacationDestination implements Serializable {
-
+public class VacationDestination {
     private Row1<Long> vacation_destination_vacation_fkey;
 
     private Row1<Long> vacationDescriptionKey;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/default/expected/CustomerTable.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/default/expected/CustomerTable.java
@@ -1,12 +1,11 @@
 package no.sikt.graphitron.example.generated.graphitron.model;
 
-import java.io.Serializable;
 import java.lang.Object;
 import java.lang.String;
 import java.util.Objects;
 import java.lang.Override;
 
-public class CustomerTable implements Serializable {
+public class CustomerTable{
     private String id;
 
     public CustomerTable() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/extendedScalarField/expected/Customer.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/extendedScalarField/expected/Customer.java
@@ -1,10 +1,9 @@
-import java.io.Serializable;
 import java.lang.Object;
 import java.lang.Override;
 import java.time.OffsetTime;
 import java.util.Objects;
 
-public class Customer implements Serializable {
+public class Customer {
     private OffsetTime time;
 
     public Customer() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/multipleFields/expected/CustomerTable.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/multipleFields/expected/CustomerTable.java
@@ -1,12 +1,11 @@
 package no.sikt.graphitron.example.generated.graphitron.model;
 
-import java.io.Serializable;
 import java.lang.Object;
 import java.lang.String;
 import java.util.Objects;
 import java.lang.Override;
 
-public class CustomerTable implements Serializable {
+public class CustomerTable {
     private String id;
 
     private String string;

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/ValidationViolationGraphQLException.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/ValidationViolationGraphQLException.java
@@ -3,9 +3,12 @@ package no.sikt.graphql.exception;
 import graphql.GraphQLError;
 import graphql.execution.AbortExecutionException;
 
+import java.io.Serial;
 import java.util.Collection;
 
 public class ValidationViolationGraphQLException extends AbortExecutionException {
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public ValidationViolationGraphQLException(Collection<GraphQLError> validationErrors) {
         super(validationErrors);

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/Vacation.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/Vacation.java
@@ -10,7 +10,11 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 import org.jooq.impl.TableImpl;
 
+import java.io.Serial;
+
 public class Vacation extends TableImpl<VacationRecord> {
+    @Serial
+    private static final long serialVersionUID = 1L;
     public static final Vacation VACATION = new Vacation();
 
     public final TableField<VacationRecord, Long> VACATION_ID = createField(DSL.name("vacation_id"), SQLDataType.BIGINT.nullable(false).identity(true), this, "");

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestination.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestination.java
@@ -10,8 +10,12 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 import org.jooq.impl.TableImpl;
 
+import java.io.Serial;
+
 @SuppressWarnings({"all", "unchecked", "rawtypes"})
 public class VacationDestination extends TableImpl<VacationDestinationRecord> {
+    @Serial
+    private static final long serialVersionUID = 1L;
     public static final VacationDestination VACATION_DESTINATION = new VacationDestination();
 
     public final TableField<VacationDestinationRecord, Long> DESTINATION_ID = createField(DSL.name("destination_id"), SQLDataType.BIGINT.nullable(false).identity(true), this, "");

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestinationRecord.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestinationRecord.java
@@ -6,8 +6,12 @@ package no.sikt.jooq.example;
 import org.jooq.Record2;
 import org.jooq.impl.UpdatableRecordImpl;
 
+import java.io.Serial;
+
 @SuppressWarnings({"all", "unchecked", "rawtypes"})
 public class VacationDestinationRecord extends UpdatableRecordImpl<VacationDestinationRecord> {
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public void setDestinationId(Long value) {
         set(0, value);

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/VacationRecord.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/VacationRecord.java
@@ -6,8 +6,13 @@ package no.sikt.jooq.example;
 import org.jooq.Record1;
 import org.jooq.impl.UpdatableRecordImpl;
 
+import java.io.Serial;
+
 @SuppressWarnings({"all", "unchecked", "rawtypes"})
 public class VacationRecord extends UpdatableRecordImpl<VacationRecord> {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public void setVacationId(Long value) {
         set(0, value);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/converters/ShortToIntegerConverter.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/converters/ShortToIntegerConverter.java
@@ -2,9 +2,12 @@ package no.sikt.graphitron.converters;
 
 import org.jooq.Converter;
 
+import java.io.Serial;
 import java.util.Optional;
 
 public class ShortToIntegerConverter implements Converter<Short, Integer> {
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     public Integer from(Short databaseObject) {

--- a/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/server/GraphqlServlet.java
+++ b/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/server/GraphqlServlet.java
@@ -16,8 +16,12 @@ import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 
+import java.io.Serial;
+
 @WebServlet(name = "GraphqlServlet", urlPatterns = {"graphql/*"}, loadOnStartup = 1)
 public class GraphqlServlet extends GraphitronServlet {
+    @Serial
+    private static final long serialVersionUID = 1L;
     private final AgroalDataSource dataSource;
 
     @Inject

--- a/graphitron-servlet-parent/graphitron-servlet/src/main/java/no/sikt/graphitron/servlet/GraphitronServlet.java
+++ b/graphitron-servlet-parent/graphitron-servlet/src/main/java/no/sikt/graphitron/servlet/GraphitronServlet.java
@@ -1,12 +1,6 @@
 package no.sikt.graphitron.servlet;
 
-import graphql.ErrorClassification;
-import graphql.ErrorType;
-import graphql.ExecutionInput;
-import graphql.ExecutionResult;
-import graphql.GraphQL;
-import graphql.GraphQLError;
-import graphql.GraphQLException;
+import graphql.*;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,10 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 public abstract class GraphitronServlet extends HttpServlet {
+    @Serial
+    private static final long serialVersionUID = 1L;
     Logger logger = LoggerFactory.getLogger(GraphitronServlet.class);
 
     @Override


### PR DESCRIPTION
- DTOs are returned by GraphQL resolvers and serialized to JSON (e.g., Jackson), not via Java Object Serialization, so Serializable is unnecessary
- prevents javac warnings from custom jOOQ Record classes, e.g. "class ...no.sikt.jooq.example.VacationRecord has no definition of serialVersionUID", by adding this field

https://sikt.atlassian.net/browse/GG-208