### PR TITLE
Fix bug when generating mappers with custom node ID columns

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -933,7 +933,7 @@ public class FormatCodeBlocks {
 
     public static CodeBlock nodeIdColumnsBlock(RecordObjectSpecification<?> obj) {
         if (obj.hasCustomKeyColumns()) {
-            return obj.getKeyColumns().stream().map(it -> CodeBlock.of("$N.$L", staticTableInstanceBlock(obj.getTable().getName()), it))
+            return obj.getKeyColumns().stream().map(it -> CodeBlock.of("$L.$L", staticTableInstanceBlock(obj.getTable().getName()), it))
                     .collect(CodeBlock.joining(", "));
         }
         return getPrimaryKeyFieldsBlock(staticTableInstanceBlock(obj.getTable().getName()));

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperNodeStrategyTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperNodeStrategyTest.java
@@ -59,6 +59,14 @@ public class MapperNodeStrategyTest extends GeneratorTest {
     }
 
     @Test
+    @DisplayName("Custom node ID field to graph with node strategy (temporary test)")
+    void toGraphCustomNodeId() {
+        assertGeneratedContentContains("toGraph/toGraphCustomNodeId",
+                "customerNode.setId(nodeIdStrategy.createId(itCustomerRecord, \"C\", Customer.CUSTOMER.CUSTOMER_ID))"
+        );
+    }
+
+    @Test
     @DisplayName("To graph with node strategy (temporary test)")
     void toGraphNotNodeId() {
         assertGeneratedContentContains("toGraph/notNodeId",

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/jooqmappers/nodeStrategy/toGraph/toGraphCustomNodeId/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/jooqmappers/nodeStrategy/toGraph/toGraphCustomNodeId/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query: CustomerNode @service(service: {name: "DUMMY_SERVICE"})
+}
+
+type CustomerNode implements Node @node(typeId: "C", keyColumns: ["CUSTOMER_ID"]) @table(name: "CUSTOMER") {
+    id: ID!
+}


### PR DESCRIPTION
Fixes `java.lang.IllegalArgumentException: expected name but was no.sikt.graphitron.jooq.generated.testdata.public_.tables.Customer.CUSTOMER` bug when generating record mappers for node IDs with custom key columns.