### PR TITLE
Support multiple primary keys in DTO

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/KeyWrapper.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/KeyWrapper.java
@@ -10,7 +10,6 @@ import no.sikt.graphitron.javapoet.TypeName;
 import no.sikt.graphql.schema.ProcessedSchema;
 import org.jooq.Key;
 import org.jooq.Typed;
-import org.jooq.UniqueKey;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -18,14 +17,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static no.sikt.graphitron.generators.dto.DTOGenerator.PRIMARY_KEY;
 import static no.sikt.graphitron.mappings.TableReflection.*;
 import static no.sikt.graphql.directives.GenerationDirective.SPLIT_QUERY;
+import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 public record KeyWrapper(Key<?> key) {
     public String getDTOVariableName() {
-        return key instanceof UniqueKey ? PRIMARY_KEY : uncapitalize(key.getName());
+        return uncapitalize(key.getName());
+    }
+
+    public String getDTOGetterName() {
+        return "get" + capitalize(key.getName());
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
@@ -20,7 +20,7 @@ import static no.sikt.graphitron.generators.codebuilding.NameFormat.RESOLVER_KEY
 import static org.apache.commons.lang3.StringUtils.capitalize;
 
 public abstract class DTOGenerator extends AbstractClassGenerator {
-    public static final String HASH_CODE = "hashCode", OBJ = "obj", EQUALS = "equals", PRIMARY_KEY = "primaryKey";
+    public static final String HASH_CODE = "hashCode", OBJ = "obj", EQUALS = "equals";
     protected final ProcessedSchema processedSchema;
 
     public DTOGenerator(ProcessedSchema processedSchema) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/InterfaceDTOGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/InterfaceDTOGenerator.java
@@ -29,7 +29,7 @@ public class InterfaceDTOGenerator extends DTOGenerator {
         (new LinkedHashSet<>(keyMap.values()))
                 .forEach(( key) -> {
                     interfaceBuilder.addMethod(
-                            MethodSpec.methodBuilder("get" + capitalize(key.key() instanceof UniqueKey ? PRIMARY_KEY : key.key().getName()))
+                            MethodSpec.methodBuilder(key.getDTOGetterName())
                                     .returns(key.getRowTypeName())
                                     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                                     .build()

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryOnlyPrimaryKeyTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryOnlyPrimaryKeyTest.java
@@ -35,8 +35,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Scalar field with splitQuery referencing another table should store primary key fields")
     void scalarReference() {
         assertGeneratedContentContains("scalarReference",
-                "VacationDestination(Record2<Long, String> primaryKey)",
-                "this.vacationDescriptionKey = primaryKey"
+                "VacationDestination(Record2<Long, String> vacation_destination_pkey)",
+                "this.vacationDescriptionKey = vacation_destination_pkey"
                 );
     }
 
@@ -44,9 +44,9 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Field with splitQuery referencing another table should store primary key fields")
     void reference() {
         assertGeneratedContentContains("reference",
-                "Row2<Long, String> primaryKey",
-                "VacationDestination(Record2<Long, String> primaryKey)",
-                "this.vacationKey = primaryKey"
+                "Row2<Long, String> vacation_destination_pkey",
+                "VacationDestination(Record2<Long, String> vacation_destination_pkey)",
+                "this.vacationKey = vacation_destination_pkey"
         );
     }
 
@@ -55,8 +55,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     void listedReference() {
         assertGeneratedContentContains("listedReference",
                 "Row1<Long> destinationKey",
-                "Vacation(Record1<Long> primaryKey)",
-                "this.destinationKey = primaryKey"
+                "Vacation(Record1<Long> vacation_pkey)",
+                "this.destinationKey = vacation_pkey"
         );
     }
 
@@ -65,8 +65,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     void reverseReference() {
         assertGeneratedContentContains("reverseReference",
                 "Row1<Long> destinationKey",
-                "Vacation(Record1<Long> primaryKey)",
-                "this.destinationKey = primaryKey"
+                "Vacation(Record1<Long> vacation_pkey)",
+                "this.destinationKey = vacation_pkey"
         );
     }
 
@@ -74,8 +74,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Connection field with splitQuery referencing another table should store primary key fields")
     void connectionReference() {
         assertGeneratedContentContains("connectionReference", Set.of(CUSTOMER_TABLE, CUSTOMER_CONNECTION),
-                "Store(Record1<Long> primaryKey)",
-                "this.customersKey = primaryKey"
+                "Store(Record1<Long> store_pkey)",
+                "this.customersKey = store_pkey"
         );
     }
 
@@ -83,8 +83,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("SplitQuery field  referencing another table with condition should store primary key fields")
     void conditionPath() {
         assertGeneratedContentContains("conditionPath",
-                "VacationDestination(Record2<Long, String> primaryKey) " +
-                        "{ this.primaryKey = primaryKey.valuesRow(); this.someStringsKey = primaryKey.valuesRow(); }",
+                "VacationDestination(Record2<Long, String> vacation_destination_pkey) " +
+                        "{ this.vacation_destination_pkey = vacation_destination_pkey.valuesRow(); this.someStringsKey = vacation_destination_pkey.valuesRow(); }",
                 "private Row2<Long, String> someStringsKey"
         );
     }
@@ -93,7 +93,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Field reference with both condition and implicit key should store primary key fields")
     void conditionWithImplicitKey() {
         assertGeneratedContentContains("conditionWithImplicitKey",
-                "this.vacationsKey = primaryKey"
+                "this.vacationsKey = vacation_destination_pkey"
         );
     }
 
@@ -101,7 +101,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Field reference with both condition and no implicit key should store primary key fields")
     void conditionWithoutImplicitKey() {
         assertGeneratedContentContains("conditionWithoutImplicitKey", Set.of(CUSTOMER_TABLE),
-                "this.customersKey = primaryKey"
+                "this.customersKey = vacation_destination_pkey"
         );
     }
 
@@ -109,8 +109,8 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Reference via tables should keep fields for first key")
     void referenceViaTable() {
         assertGeneratedContentContains("referenceViaTable",
-                "Inventory(Record1<Long> primaryKey)",
-                "this.staffForInventoryKey = primaryKey"
+                "Inventory(Record1<Long> inventory_pkey)",
+                "this.staffForInventoryKey = inventory_pkey"
         );
     }
 
@@ -118,9 +118,9 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Key fields should be reused when multiple splitQuery fields use the same key")
     void multipleFieldsWithSameKey() {
         assertGeneratedContentContains("multipleFieldsWithSameKey",
-                "Inventory(Record1<Long> primaryKey)",
-                "this.store1Key = primaryKey",
-                "this.store2Key = primaryKey"
+                "Inventory(Record1<Long> inventory_pkey)",
+                "this.store1Key = inventory_pkey",
+                "this.store2Key = inventory_pkey"
         );
     }
 
@@ -128,7 +128,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Subtype with splitQuery reference should store primary key fields")
     void referenceInSubtype() {
         assertGeneratedContentContains("referenceInSubtype",
-                "SomeType(Record1<Long> primaryKey)"
+                "SomeType(Record1<Long> customer_pkey)"
         );
     }
 
@@ -137,7 +137,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     void selfReference() {
         assertGeneratedContentContains("selfReference",
                 "Row1<Long> sequelKey",
-                "this.sequelKey = primaryKey"
+                "this.sequelKey = film_pkey"
         );
     }
 
@@ -153,7 +153,7 @@ public class DTOSplitQueryOnlyPrimaryKeyTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void conditionPathFromInterfaceWithTable() {
         assertGeneratedContentContains("conditionPathFromInterfaceWithTable",
-                "Row2<Long, String> getPrimaryKey()",
+                "Row2<Long, String> getVacation_destination_pkey()",
                 "Row2<Long, String> getSomeStringKey()"
         );
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
@@ -59,8 +59,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void listedReference() {
         assertGeneratedContentContains("listedReference",
                 "Row1<Long> destinationKey",
-                "Vacation(Record1<Long> primaryKey)",
-                "this.destinationKey = primaryKey"
+                "Vacation(Record1<Long> vacation_pkey)",
+                "this.destinationKey = vacation_pkey"
         );
     }
 
@@ -69,8 +69,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void reverseReference() {
         assertGeneratedContentContains("reverseReference",
                 "Row1<Long> destinationKey",
-                "Vacation(Record1<Long> primaryKey)",
-                "this.destinationKey = primaryKey"
+                "Vacation(Record1<Long> vacation_pkey)",
+                "this.destinationKey = vacation_pkey"
         );
     }
 
@@ -78,8 +78,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Connection field with splitQuery referencing another table should store primary key fields")
     void connectionReference() {
         assertGeneratedContentContains("connectionReference", Set.of(CUSTOMER_TABLE, CUSTOMER_CONNECTION),
-                "Store(Record1<Long> primaryKey)",
-                "this.customersKey = primaryKey"
+                "Store(Record1<Long> store_pkey)",
+                "this.customersKey = store_pkey"
         );
     }
 
@@ -87,8 +87,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("SplitQuery field  referencing another table with condition should store primary key fields")
     void conditionPath() {
         assertGeneratedContentContains("conditionPath",
-                "VacationDestination(Record2<Long, String> primaryKey) " +
-                        "{ this.primaryKey = primaryKey.valuesRow(); this.someStringsKey = primaryKey.valuesRow(); }",
+                "VacationDestination(Record2<Long, String> vacation_destination_pkey) " +
+                        "{ this.vacation_destination_pkey = vacation_destination_pkey.valuesRow(); this.someStringsKey = vacation_destination_pkey.valuesRow(); }",
                 "private Row2<Long, String> someStringsKey"
         );
     }
@@ -105,7 +105,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field reference with both condition and no implicit key should store primary key fields")
     void conditionWithoutImplicitKey() {
         assertGeneratedContentContains("conditionWithoutImplicitKey", Set.of(CUSTOMER_TABLE),
-                "this.customersKey = primaryKey"
+                "this.customersKey = vacation_destination_pkey"
         );
     }
 
@@ -157,7 +157,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Single table interface with splitQuery field")
     void conditionPathFromInterfaceWithTable() {
         assertGeneratedContentContains("conditionPathFromInterfaceWithTable",
-                "Row2<Long, String> getPrimaryKey()",
+                "Row2<Long, String> getVacation_destination_pkey()",
                 "Row2<Long, String> getSomeStringKey()"
         );
     }
@@ -198,8 +198,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing single table interface")
     void referencingSingleTableInterface() {
         assertGeneratedContentContains("referencingSingleTableInterface", Set.of(ADDRESS_BY_DISTRICT),
-                "City(Record1<Long> primaryKey)",
-                "this.addressesKey = primaryKey"
+                "City(Record1<Long> city_pkey)",
+                "this.addressesKey = city_pkey"
         );
     }
 
@@ -207,8 +207,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing single table interface connection")
     void referencingSingleTableInterfaceConnection() {
         assertGeneratedContentContains("referencingSingleTableInterfaceConnection", Set.of(ADDRESS_BY_DISTRICT, ADDRESS_BY_DISTRICT_CONNECTION),
-                "City(Record1<Long> primaryKey)",
-                "this.addressesKey = primaryKey"
+                "City(Record1<Long> city_pkey)",
+                "this.addressesKey = city_pkey"
         );
     }
 
@@ -216,8 +216,8 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable interface")
     void referencingMultitableInterface() {
         assertGeneratedContentContains("referencingMultitableInterface",
-                "FilmCategory(Record2<Long, Long> primaryKey)",
-                "this.titledFilmsKey = primaryKey"
+                "FilmCategory(Record2<Long, Long> film_category_pkey)",
+                "this.titledFilmsKey = film_category_pkey"
         );
     }
 
@@ -225,7 +225,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable interface connection")
     void referencingMultitableInterfaceConnection() {
         assertGeneratedContentContains("referencingMultitableInterfaceConnection",
-                "this.titledFilmsKey = primaryKey"
+                "this.titledFilmsKey = film_category_pkey"
         );
     }
 
@@ -233,7 +233,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable union")
     void referencingMultitableUnion() {
         assertGeneratedContentContains("referencingMultitableUnion",
-                "this.filmsKey = primaryKey"
+                "this.filmsKey = film_category_pkey"
         );
     }
 
@@ -241,7 +241,7 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @DisplayName("Field referencing multitable interface union")
     void referencingMultitableUnionConnection() {
         assertGeneratedContentContains("referencingMultitableUnionConnection",
-                "this.filmsKey = primaryKey"
+                "this.filmsKey = film_category_pkey"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
@@ -1,5 +1,6 @@
 package no.sikt.graphitron.dto;
 
+import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
 import no.sikt.graphitron.generators.abstractions.ClassGenerator;
 import no.sikt.graphitron.generators.dto.TypeDTOGenerator;
 import no.sikt.graphql.schema.ProcessedSchema;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.JAVA_RECORD_CUSTOMER;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.*;
 
 public class TypeDTOGeneratorTest extends DTOGeneratorTest {
@@ -32,6 +34,11 @@ public class TypeDTOGeneratorTest extends DTOGeneratorTest {
     @DisplayName("Type with multiple fields")
     void multipleFields() {
         assertGeneratedContentMatches("multipleFields");
+    }
+
+    @Override
+    protected Set<ExternalReference> getExternalReferences() {
+        return makeReferences(JAVA_RECORD_CUSTOMER);
     }
 
     @Test
@@ -99,6 +106,15 @@ public class TypeDTOGeneratorTest extends DTOGeneratorTest {
                 "Customer(String id, List<ErrorUnion> errors)",
                 "this.errors = errors",
                 "Customer(String id){this.id = id;this.errors = null"
+        );
+    }
+
+    @Test
+    @DisplayName("Type for java record")
+    void javaRecord() {
+        assertGeneratedContentContains(
+                "javaRecord",
+                "MyJavaRecord(Record1<Long> address_pkey, Record1<Long> city_pkey)"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/javaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/javaRecord/schema.graphqls
@@ -1,0 +1,12 @@
+type MyJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: Address @splitQuery
+    city: City @splitQuery
+}
+
+type Address @table {
+    id: ID
+}
+
+type City @table {
+    id: ID
+}


### PR DESCRIPTION
Use key name instead of `primaryKey` in order to support multiple primary keys in DTOs, which is needed for java record types which may have multiple `splitQuery` fields.
