### PR TITLE
Support splitQuery fields in nested java records

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
@@ -7,14 +7,14 @@ import no.sikt.graphitron.generators.context.MapperContext;
 import no.sikt.graphitron.generators.dependencies.Dependency;
 import no.sikt.graphitron.javapoet.CodeBlock;
 import no.sikt.graphitron.javapoet.MethodSpec;
-import no.sikt.graphitron.javapoet.ParameterizedTypeName;
 import no.sikt.graphitron.javapoet.TypeName;
 import no.sikt.graphql.schema.ProcessedSchema;
 
 import javax.lang.model.element.Modifier;
 import java.util.List;
 
-import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.*;
+import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.addStringIfNotEmpty;
+import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.asMethodCall;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.asListedName;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.recordTransformMethod;
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.wrapArrayList;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/MapperContext.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/MapperContext.java
@@ -442,11 +442,12 @@ public class MapperContext {
      */
     private CodeBlock transformRecord() {
         return CodeBlock.of(
-                "$L$N + $S$L)",
+                "$L$L$N + $S$L)",
                 recordTransformPart(
                         previousContext.hasSourceName() ? getHelperVariableName() : asRecordName(previousContext.getTargetName()),
                         uncapitalize(targetType.getName())
                 ),
+                CodeBlock.ofIf(shouldMakeNodeStrategy(), "$N, ", NODE_ID_STRATEGY_NAME),
                 PATH_HERE_NAME,
                 path,
                 CodeBlock.ofIf(recordValidationEnabled() && !hasJavaRecordReference && toRecord, ", $N + $S", PATH_HERE_NAME, path) // This one may need more work. Does not actually include indices here, but not sure if needed.

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
@@ -56,10 +56,10 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
                 innerCode.add(innerContext.getResolverKeySetMappingBlockForJooqRecord());
             } else if (!isType) {
                 innerCode.add(innerContext.getFieldSetMappingBlock());
-            } else if (!innerField.isResolver() && !innerContext.hasTable()) {
-                innerCode.add(iterateRecords(innerContext));
             } else if (!previousHadSource) {
                 innerCode.add(innerContext.getRecordSetMappingBlock());
+            } else if (!innerField.isResolver() && !innerContext.hasTable()) {
+                innerCode.add(iterateRecords(innerContext));
             }
 
             if (!innerCode.isEmpty()) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/codereferences/services/MapperFetchService.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/codereferences/services/MapperFetchService.java
@@ -1,5 +1,6 @@
 package no.sikt.graphitron.codereferences.services;
 
+import no.sikt.graphitron.codereferences.records.CustomerJavaRecord;
 import no.sikt.graphitron.jooq.generated.testdata.public_.tables.records.CustomerRecord;
 import org.jooq.DSLContext;
 
@@ -14,4 +15,9 @@ public class MapperFetchService {
     public List<CustomerRecord> customerQuery() {
         return null;
     }
+
+    public List<CustomerJavaRecord> customerJavaQuery() {
+        return null;
+    }
+
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperNodeStrategyTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperNodeStrategyTest.java
@@ -2,6 +2,7 @@ package no.sikt.graphitron.jooqrecordmappers;
 
 import no.sikt.graphitron.common.GeneratorTest;
 import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
 import no.sikt.graphitron.generators.abstractions.ClassGenerator;
 import no.sikt.graphitron.generators.mapping.RecordMapperClassGenerator;
 import no.sikt.graphitron.generators.mapping.TransformerClassGenerator;
@@ -14,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.JAVA_RECORD_CUSTOMER;
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.MAPPER_FETCH_SERVICE;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_NODE;
 
 @DisplayName("Mappers with node strategy (temporary test class)")
@@ -40,6 +43,11 @@ public class MapperNodeStrategyTest extends GeneratorTest {
     @AfterAll
     static void tearDown() {
         GeneratorConfig.setNodeStrategy(false);
+    }
+
+    @Override
+    protected Set<ExternalReference> getExternalReferences() {
+        return makeReferences(JAVA_RECORD_CUSTOMER, MAPPER_FETCH_SERVICE);
     }
 
     @Test
@@ -103,6 +111,15 @@ public class MapperNodeStrategyTest extends GeneratorTest {
     void toRecordWithReferenceKey() {
         assertGeneratedContentContains("toRecord/withReferenceKey", Set.of(CUSTOMER_NODE),
                 "nodeIdStrategy.setReferenceId(customerRecord, itCustomerInputTable.getAddressId(), \"Address\", Customer.CUSTOMER.ADDRESS_ID)"
+        );
+    }
+
+    @Test
+    @DisplayName("Wrapper field containing listed Java record with splitQuery field")
+    void listedFieldWithJavaRecord() {
+        assertGeneratedContentContains(
+                "toGraph/splitQueryInNestedJavaRecord",
+                "customerJavaRecordToGraphType(payloadRecord, nodeIdStrategy, pathHere + \"customerJavaRecords\")"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/schemamappers/MapperGeneratorToGraphTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/schemamappers/MapperGeneratorToGraphTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
-import static no.sikt.graphitron.common.configuration.ReferencedEntry.MAPPER_ID_SERVICE;
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.*;
 
 @DisplayName("Schema Mappers - Mapper content for mapping fields to graph types")
 public class MapperGeneratorToGraphTest extends GeneratorTest {
@@ -22,7 +22,7 @@ public class MapperGeneratorToGraphTest extends GeneratorTest {
 
     @Override
     protected Set<ExternalReference> getExternalReferences() {
-        return makeReferences(MAPPER_ID_SERVICE);
+        return makeReferences(MAPPER_ID_SERVICE, JAVA_RECORD_CUSTOMER, MAPPER_FETCH_SERVICE);
     }
 
     @Override
@@ -43,6 +43,16 @@ public class MapperGeneratorToGraphTest extends GeneratorTest {
                 "listedFields",
                 "Response0 recordToGraphType(List<String> response0Record,",
                 "Response1 recordToGraphType(List<String> response1Record,"
+        );
+    }
+
+    @Test
+    @DisplayName("Wrapper field containing listed Java record with splitQuery field")
+    void listedFieldWithJavaRecord() {
+        assertGeneratedContentContains(
+                "splitQueryInNestedJavaRecord",
+                " if (select.contains(pathHere + \"customerJavaRecords\")) {" +
+                        "payload.setCustomerJavaRecords(transform.customerJavaRecordToGraphType(payloadRecord, pathHere + \"customerJavaRecords\"));}"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/jooqmappers/nodeStrategy/toGraph/splitQueryInNestedJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/jooqmappers/nodeStrategy/toGraph/splitQueryInNestedJavaRecord/schema.graphqls
@@ -1,0 +1,15 @@
+type Query {
+    query: Payload @service(service: {name: "MAPPER_FETCH_SERVICE", method: "customerJavaQuery"})
+}
+
+type Payload {
+    customerJavaRecords: [CustomerJavaRecord]
+}
+
+type CustomerJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: Address @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/schemamappers/splitQueryInNestedJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/schemamappers/splitQueryInNestedJavaRecord/schema.graphqls
@@ -1,0 +1,15 @@
+type Query {
+    query: Payload @service(service: {name: "MAPPER_FETCH_SERVICE", method: "customerJavaQuery"})
+}
+
+type Payload {
+    customerJavaRecords: [CustomerJavaRecord]
+}
+
+type CustomerJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: Address @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_nested_java_record-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_nested_java_record-1.result.approved.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "mockUpdateAddressAndCustomer": {
+            "result": {
+                "address": {
+                    "id": "QWRkcmVzczoxNA"
+                },
+                "customer": {
+                    "id": "Q3VzdG9tZXI6Ng"
+                },
+                "extraAddress": {
+                    "id": "QWRkcmVzczo5"
+                }
+            }
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_nested_java_record.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_nested_java_record.graphql
@@ -1,0 +1,15 @@
+{
+    mockUpdateAddressAndCustomer {
+        result {
+            address {
+                id
+            }
+            customer {
+                id
+            }
+            extraAddress {
+                id
+            }
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
@@ -1,0 +1,30 @@
+package no.sikt.graphitron.example.service;
+
+import no.sikt.graphitron.example.generated.jooq.tables.records.AddressRecord;
+import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
+import no.sikt.graphitron.example.service.records.MockUpdateAddressAndCustomerResultRecord;
+import org.jooq.DSLContext;
+
+public class MockService {
+
+    public MockService(DSLContext context) {
+    }
+
+    public MockUpdateAddressAndCustomerResultRecord mockUpdateAddressAndCustomer() {
+        var result = new MockUpdateAddressAndCustomerResultRecord();
+
+        var address1 = new AddressRecord();
+        address1.setAddressId(9);
+        result.setMyAddress(address1);
+
+        var address2 = new AddressRecord();
+        address2.setAddressId(14);
+        result.setAddress(address2);
+
+        var customer = new CustomerRecord();
+        customer.setCustomerId(6);
+        result.setCustomer(customer);
+
+        return result;
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/MockUpdateAddressAndCustomerResultRecord.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/MockUpdateAddressAndCustomerResultRecord.java
@@ -1,0 +1,36 @@
+package no.sikt.graphitron.example.service.records;
+
+import no.sikt.graphitron.example.generated.jooq.tables.records.AddressRecord;
+import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
+
+public class MockUpdateAddressAndCustomerResultRecord {
+    private AddressRecord myAddress;
+    private AddressRecord address;
+
+    public AddressRecord getAddress() {
+        return address;
+    }
+
+    public void setAddress(AddressRecord address) {
+        this.address = address;
+    }
+
+    private CustomerRecord customer;
+
+
+    public CustomerRecord getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(CustomerRecord customer) {
+        this.customer = customer;
+    }
+
+    public AddressRecord getMyAddress() {
+        return myAddress;
+    }
+
+    public void setMyAddress(AddressRecord myAddress) {
+        this.myAddress = myAddress;
+    }
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
@@ -7,6 +7,18 @@ extend type Query {
     customerService: Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
     customerServiceWithJooqRecordInput(input: CustomerInput!): Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
     customerServiceWithJavaRecordInput(input: HelloWorldInputObject!): Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
+
+    mockUpdateAddressAndCustomer: MockUpdateAddressAndCustomerPayload @service(service: {className: "no.sikt.graphitron.example.service.MockService"})
+}
+
+type MockUpdateAddressAndCustomerPayload {
+    result: MockUpdateAddressAndCustomerResult
+}
+
+type MockUpdateAddressAndCustomerResult @record(record: {className: "no.sikt.graphitron.example.service.records.MockUpdateAddressAndCustomerResultRecord"}) {
+    customer: Customer @splitQuery
+    address: Address @splitQuery
+    extraAddress: Address @field(name: "myAddress") @splitQuery
 }
 
 type HelloWorldObject @record(record: {className: "no.sikt.graphitron.example.service.records.HelloWorldRecord"}){


### PR DESCRIPTION
Dette skal fikse sånn at du kan endre fra `fetchById` til `splitQuery` for `OpprettFagpersonForGittFodselsnummerResult` og `OpprettFagpersonGittPassResult`