### PR TITLE
Support regular ID fields in queries with node strategy

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static no.sikt.graphitron.configuration.GeneratorConfig.shouldMakeNodeStrategy;
 import static no.sikt.graphitron.configuration.GeneratorConfig.useOptionalSelects;
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.*;
 import static no.sikt.graphitron.generators.codebuilding.KeyWrapper.getKeyRowTypeName;
@@ -512,7 +513,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         }
 
         var renderedSource = field.isInput() ? context.iterateJoinSequenceFor(field).render() : context.renderQuerySource(getLocalTable());
-        if (field.isID()) {
+        if (field.isID() && !shouldMakeNodeStrategy()) {
             return CodeBlock.join(
                     renderedSource,
                     generateGetForID(field.getMappingFromFieldOverride(), context.getCurrentJoinSequence().isEmpty() ? null : context.getCurrentJoinSequence().getLast().getTable())
@@ -709,7 +710,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
             );
         }
 
-        if (field.isID()) {
+        if (field.isID() && !shouldMakeNodeStrategy()) {
             var isInRecordInput = processedSchema.isInputType(field.getContainerTypeName()) && processedSchema.hasJOOQRecord(field.getContainerTypeName());
             var table = isInRecordInput ? context.getCurrentJoinSequence().getLast().getTable() : context.iterateJoinSequenceFor(field).getLast().getTable();
             return CodeBlock.join(renderedSequence, generateHasForID(field.getMappingFromFieldOverride(), table, name, field.isIterableWrapped()));

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/StrategyNodeInterfaceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/StrategyNodeInterfaceTest.java
@@ -54,6 +54,20 @@ public class StrategyNodeInterfaceTest extends GeneratorTest {
     }
 
     @Test
+    @DisplayName("ID field which is not node ID")
+    void regularIdField() {
+        assertGeneratedContentContains("regularIdField", "_customer.CUSTOMER_ID");
+    }
+
+    @Test
+    @DisplayName("Input ID field which is not node ID")
+    void regularIdInputField() {
+        assertGeneratedContentContains("regularIdInputField", Set.of(CUSTOMER_TABLE),
+                "_customer.CUSTOMER_ID.eq(id)"
+        );
+    }
+
+    @Test
     @DisplayName("Multiple fields")
     void manyFields() {
         assertGeneratedContentContains("manyFields", "_customer.FIRST_NAME", "_customer.LAST_NAME");

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/regularIdField/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/regularIdField/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  customer: Customer
+}
+
+type Customer @table {
+  id: ID @field(name: "CUSTOMER_ID")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/regularIdInputField/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/regularIdInputField/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  customer(id: ID! @field(name: "CUSTOMER_ID")): CustomerTable
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
@@ -21,7 +21,7 @@ type Query {
     filmLookupWithAdditionalField(filmId: [String!]! @lookupKey @field(name: "FILM_ID"), title: [String!] @lookupKey): [Film]
     filmLookupWithInputObject(filmIds: [FilmLookupInput] @lookupKey): [Film]
 
-    filmLists(category: String): [FilmList]
+    filmLists(category: String, categoryAsId: ID @field(name: "CATEGORY")): [FilmList]
     filmListsWithEnumRecord(input: FilmListEnumInput!): FilmList
     filmsWithDescriptionInput(input: [FilmDescriptionInput]): [Film]
 
@@ -76,6 +76,7 @@ type Customer implements Node @node @table {
     id: ID!
     name: CustomerName
     email: String
+    emailAsId: ID @field(name: "EMAIL")
     address: Address!
     addressSplitQuery: Address @splitQuery
 }


### PR DESCRIPTION
Dette er starten av å fjerne spesialbehandling av IDer. Bakgrunnen er at Alf mener et ID felt i utdanningsregisteret skal peke mot [ID-kolonnen](https://sikt.atlassian.net/browse/GG-242), selv om dette åpenbart aldri har blitt riktig generert.

Det blir lettere å ta en ordentlig runde på å fjerne alt av spesialbehandlingen senere, og tror ikke det er nødvendig helt enda. Har derfor i første omgang kun endret til å behandle dem som vanlig felt (både input og output) i queryer.

