### PR TITLE
GG-261 support listed splitQuery fields in java records

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/ResolverMethodGenerator.java
@@ -86,6 +86,17 @@ abstract public class ResolverMethodGenerator extends AbstractSchemaMethodGenera
                     .build();
         }
 
+        if (processedSchema.isOrderedMultiKeyQuery(target)) {
+            return CodeBlock.statementOf(
+                    "return $L.$L($N.$L(), $L)",
+                    newDataFetcher(),
+                    "loadByResolverKeys",
+                    uncapitalize(localObject.getName()),
+                    getDTOGetterMethodNameForField(target),
+                    queryFunction
+            );
+        }
+
         // If this method is the mutating method of a mutation. In other words, it is not the query that returns the final result.
         if (!isMutatingMethod) {
             return callQueryBlock(target, objectToCall, methodName, parser, queryFunction);

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -1066,7 +1066,9 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         if (isRoot && !lookupExists) {
             return wrapListIf(type, referenceField.isIterableWrapped() || referenceField.hasForwardPagination());
         } else if (!isRoot) {
-            return wrapMap(getKeyRowTypeName(referenceField, processedSchema), wrapListIf(type, referenceField.isIterableWrapped() && !lookupExists || referenceField.hasForwardPagination()));
+            return wrapMap(
+                    getKeyRowTypeName(referenceField, processedSchema),
+                    wrapListIf(type, referenceField.isIterableWrapped() && !processedSchema.isOrderedMultiKeyQuery(referenceField) || referenceField.hasForwardPagination()));
         } else {
             return wrapMap(STRING.className, wrapListIf(type, referenceField.hasForwardPagination()));
         }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -1296,10 +1296,6 @@ public class ProcessedDefinitionsValidator {
                         errorMessages.add(errorMessageStart + " does not return a type with table. This is not supported.");
                     }
 
-                    if (field.isIterableWrapped()) {
-                        errorMessages.add(errorMessageStart + " is listed. This is not currently supported.");
-                    }
-
                     if (field.hasForwardPagination()) {
                         errorMessages.add(errorMessageStart + " is paginated. This is not supported.");
                     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphql/schema/ProcessedSchema.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphql/schema/ProcessedSchema.java
@@ -598,10 +598,17 @@ public class ProcessedSchema {
     }
 
     /**
-     * @return Does this field point to an input type with a Java record set in the schema?
+     * @return Does this type name point to a type with a Java record?
+     */
+    public boolean hasJavaRecord(String typeName) {
+        return Optional.ofNullable(getRecordType(typeName)).map(RecordObjectSpecification::hasJavaRecordReference).orElse(false);
+    }
+
+    /**
+     * @return Does this field point to a type with a Java record set in the schema?
      */
     public boolean hasJavaRecord(GenerationField field) {
-        return Optional.ofNullable(getRecordType(field)).map(RecordObjectSpecification::hasJavaRecordReference).orElse(false);
+        return hasJavaRecord(field.getTypeName());
     }
 
     /**
@@ -609,6 +616,13 @@ public class ProcessedSchema {
      */
     public boolean hasRecord(GenerationField field) {
         return Optional.ofNullable(getRecordType(field)).map(RecordObjectSpecification::hasRecordReference).orElse(false);
+    }
+
+    /**
+     * @return Is this an ordered multi-key query?
+     */
+    public boolean isOrderedMultiKeyQuery(GenerationField field) {
+        return field.isIterableWrapped() && field.isResolver() && hasJavaRecord(field.getContainerTypeName());
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/DTOSplitQueryTest.java
@@ -1,6 +1,7 @@
 package no.sikt.graphitron.dto;
 
 import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
 import no.sikt.graphitron.generators.abstractions.ClassGenerator;
 import no.sikt.graphitron.generators.dto.InterfaceDTOGenerator;
 import no.sikt.graphitron.generators.dto.TypeDTOGenerator;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Set;
 
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.JAVA_RECORD_CUSTOMER;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,6 +38,11 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     @Override
     protected String getSubpath() {
         return super.getSubpath() + "splitQuery";
+    }
+
+    @Override
+    protected Set<ExternalReference> getExternalReferences() {
+        return makeReferences(JAVA_RECORD_CUSTOMER);
     }
 
     @Test
@@ -242,6 +249,23 @@ public class DTOSplitQueryTest extends DTOGeneratorTest {
     void referencingMultitableUnionConnection() {
         assertGeneratedContentContains("referencingMultitableUnionConnection",
                 "this.filmsKey = film_category_pkey"
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple keys in java record")
+    void multipleKeysInJavaRecord() {
+        assertGeneratedContentContains("multipleKeysInJavaRecord",
+                "private Row1<Long> addressKey; private Row1<Long> cityKey;"
+        );
+    }
+
+    @Test
+    @DisplayName("Listed resolver keys for java record")
+    void listedKeyInJavaRecord() {
+        assertGeneratedContentContains("listedKeyInJavaRecord",
+                "private List<Row1<Long>> addressKey;",
+                "setAddressKey(List<Row1<Long>> addressKey) { this.addressKey = addressKey;"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/dto/TypeDTOGeneratorTest.java
@@ -112,9 +112,6 @@ public class TypeDTOGeneratorTest extends DTOGeneratorTest {
     @Test
     @DisplayName("Type for java record")
     void javaRecord() {
-        assertGeneratedContentContains(
-                "javaRecord",
-                "MyJavaRecord(Record1<Long> address_pkey, Record1<Long> city_pkey)"
-        );
+        assertGeneratedContentMatches("javaRecord");
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToGraphTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToGraphTest.java
@@ -139,6 +139,15 @@ public class JavaMapperGeneratorToGraphTest extends GeneratorTest {
     }
 
     @Test
+    @DisplayName("Sets resolver keys for listed field with splitQuery")
+    void splitQueryListed() {
+        assertGeneratedContentContains(
+                "splitQueryListed",
+                "customer.setAddressKey(address.stream().map(internal_it_ -> DSL.row(internal_it_.getAddressId())).toList());"
+        );
+    }
+
+    @Test
     @DisplayName("Skips fields that are not mapped to a record field")
     void unconfiguredField() {
         assertGeneratedContentContains(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/RecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/RecordTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.ReferencedEntry.DUMMY_RECORD;
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.JAVA_RECORD_CUSTOMER;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_INPUT_TABLE;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
 
@@ -25,7 +26,7 @@ public class RecordTest extends GeneratorTest {
 
     @Override
     protected Set<ExternalReference> getExternalReferences() {
-        return makeReferences(DUMMY_RECORD);
+        return makeReferences(DUMMY_RECORD, JAVA_RECORD_CUSTOMER);
     }
 
     @Override

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceSplitQueryTest.java
@@ -331,6 +331,16 @@ public class ReferenceSplitQueryTest extends ReferenceTest {
     }
 
     @Test
+    @DisplayName("Listed splitQuery field after service returning java record")
+    void afterJavaServiceListed() {
+        assertGeneratedContentContains(
+                "afterJavaServiceListed", Set.of(CUSTOMER_TABLE),
+                "Map<Row1<Long>, Address> addressForCustomer(DSLContext ctx, Set<Row1<Long>> customerResolverKeys",
+                ".select(DSL.row(_address.ADDRESS_ID), DSL.row(_address"
+        );
+    }
+
+    @Test
     @DisplayName("Nested splitQuery field after service returning java record")
     void afterJavaServiceNested() {
         assertGeneratedContentContains(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/resolvers/datafetchers/standard/fetch/ResolverTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/resolvers/datafetchers/standard/fetch/ResolverTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.ReferencedEntry.CONTEXT_CONDITION;
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.JAVA_RECORD_CUSTOMER;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.*;
 
 @DisplayName("Fetch resolvers - Resolvers for queries")
@@ -36,7 +37,7 @@ public class ResolverTest extends GeneratorTest {
 
     @Override
     protected Set<ExternalReference> getExternalReferences() {
-        return makeReferences(CONTEXT_CONDITION);
+        return makeReferences(CONTEXT_CONDITION, JAVA_RECORD_CUSTOMER);
     }
 
     @Override
@@ -195,6 +196,23 @@ public class ResolverTest extends GeneratorTest {
         assertGeneratedContentContains("operation/singleTableInterface",
                 "CompletableFuture<List<Address>>",
                 "QueryDBQueries.addressForQuery("
+        );
+    }
+
+    @Test
+    @DisplayName("SplitQuery field in Java record")
+    void splitQueryFromJavaRecord() {
+        assertGeneratedContentContains("splitquery/splitQueryFromJavaRecord",
+                "load(",
+                "addressForMyJavaRecord"
+        );
+    }
+
+    @Test
+    @DisplayName("Listed splitQuery field in Java record")
+    void listedSplitQueryFromJavaRecord() {
+        assertGeneratedContentContains("splitquery/listedSplitQueryFromJavaRecord",
+                "return new DataFetcherHelper(env).loadByResolverKeys(myJavaRecord.getAddressKey()"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/schemamappers/MapperGeneratorToGraphTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/schemamappers/MapperGeneratorToGraphTest.java
@@ -48,11 +48,20 @@ public class MapperGeneratorToGraphTest extends GeneratorTest {
 
     @Test
     @DisplayName("Wrapper field containing listed Java record with splitQuery field")
-    void listedFieldWithJavaRecord() {
+    void splitQueryInNestedJavaRecord() {
         assertGeneratedContentContains(
                 "splitQueryInNestedJavaRecord",
                 " if (select.contains(pathHere + \"customerJavaRecords\")) {" +
                         "payload.setCustomerJavaRecords(transform.customerJavaRecordToGraphType(payloadRecord, pathHere + \"customerJavaRecords\"));}"
+        );
+    }
+
+    @Test
+    @DisplayName("Wrapper field containing listed jOOQ record with listed splitQuery field")
+    void listedSplitQueryInNestedJavaRecord() {
+        assertGeneratedContentContains(
+                "listedSplitQueryInNestedJooqRecord",
+                "customer.setAddressesKey(DSL.row(itCustomerRecord.getCustomerId()));"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/SplitQueryAfterJavaServiceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/SplitQueryAfterJavaServiceTest.java
@@ -22,12 +22,9 @@ public class SplitQueryAfterJavaServiceTest extends ValidationTest {
     }
 
     @Test
-    @DisplayName("Listed field is not currently supported")
+    @DisplayName("Listed field is supported")
     void listed() {
-        assertErrorsContain("listed", Set.of(CUSTOMER_TABLE),
-                "'DummyTypeRecord.customer' in a java record has splitQuery directive, " +
-                        "but is listed. This is not currently supported."
-        );
+        getProcessedSchema("listed", Set.of(CUSTOMER_TABLE));
     }
 
     @Test

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/listedKeyInJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/listedKeyInJavaRecord/schema.graphqls
@@ -1,0 +1,7 @@
+type MyJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: [Address] @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/multipleKeysInJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/splitQuery/multipleKeysInJavaRecord/schema.graphqls
@@ -1,0 +1,12 @@
+type MyJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: Address @splitQuery
+    city: City @splitQuery
+}
+
+type Address @table {
+    id: ID
+}
+
+type City @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/javaRecord/expected/MyJavaRecord.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/dto/type/javaRecord/expected/MyJavaRecord.java
@@ -1,0 +1,38 @@
+package no.sikt.graphitron.example.generated.graphitron.model;
+
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Objects;
+
+public class MyJavaRecord {
+    private String myString;
+
+    public MyJavaRecord() {
+    }
+
+    public String getMyString() {
+        return myString;
+    }
+
+    public void setMyString(String myString) {
+        this.myString = myString;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(myString);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final MyJavaRecord that = (MyJavaRecord) obj;
+        return Objects.equals(myString, that.myString);
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/javamappers/tograph/splitQueryListed/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/javamappers/tograph/splitQueryListed/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+  query: Customer
+}
+
+type Customer @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+  address: [Address] @splitQuery
+}
+
+type Address @table {
+  id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/afterJavaServiceListed/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/splitQuery/afterJavaServiceListed/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+    query: Customer @service(service: {name: "DUMMY_SERVICE"})
+}
+
+type Customer @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: [Address] @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/datafetchers/fetch/standard/splitquery/listedSplitQueryFromJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/datafetchers/fetch/standard/splitquery/listedSplitQueryFromJavaRecord/schema.graphqls
@@ -1,0 +1,7 @@
+type MyJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
+    address: [Address] @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/datafetchers/fetch/standard/splitquery/splitQueryFromJavaRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/resolvers/datafetchers/fetch/standard/splitquery/splitQueryFromJavaRecord/schema.graphqls
@@ -1,3 +1,7 @@
 type MyJavaRecord @record(record: {name: "JAVA_RECORD_CUSTOMER"}) {
-    myString: String
+    address: Address @splitQuery
+}
+
+type Address @table {
+    id: ID
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/schemamappers/listedSplitQueryInNestedJooqRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/schemamappers/listedSplitQueryInNestedJooqRecord/schema.graphqls
@@ -1,0 +1,15 @@
+type Query {
+    query: Payload @service(service: {className: "MapperFetchService", method: "customerQuery"})
+}
+
+type Payload {
+    customers: [Customer]
+}
+
+type Customer @table {
+    addresses: [Address] @splitQuery
+}
+
+type Address @table {
+    id: ID
+}

--- a/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/TypeSpec.java
+++ b/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/TypeSpec.java
@@ -778,6 +778,13 @@ public final class TypeSpec {
             return this;
         }
 
+        public Builder addMethodIf(boolean predicate, MethodSpec methodSpec) {
+            if (predicate) {
+                addMethod(methodSpec);
+            }
+            return this;
+        }
+
         public Builder addTypes(Iterable<TypeSpec> typeSpecs) {
             checkArgument(typeSpecs != null, "typeSpecs == null");
             for (TypeSpec typeSpec : typeSpecs) {

--- a/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
@@ -126,12 +126,7 @@ public class DataFetcherHelper extends AbstractFetcher {
         if (keys.isEmpty()) {
             return CompletableFuture.completedFuture(List.of());
         }
-
-        var mergedKeys = mergeKeys(keys, env);
-
-        var dbResult = dbFunction.callDBMethod(dslContext, new HashSet<>(mergedKeys), select);
-        var orderedResult = mergedKeys.stream().map(dbResult::get).collect(Collectors.toList());
-        return CompletableFuture.completedFuture(orderedResult);
+        return loadByKeysOrdered(mergeKeys(keys, env), dbFunction);
     }
 
     public static <K> List<String> mergeKeys(List<List<K>> keys, DataFetchingEnvironment env) {
@@ -163,6 +158,19 @@ public class DataFetcherHelper extends AbstractFetcher {
         }
 
         return mergedKeys;
+    }
+
+    public <K, V> CompletableFuture<List<V>> loadByResolverKeys(List<K> keys, DBQuery<K, V> dbFunction) {
+        if (keys.isEmpty()) {
+            return CompletableFuture.completedFuture(List.of());
+        }
+        return loadByKeysOrdered(keys, dbFunction);
+    }
+
+    private <K, V> CompletableFuture<List<V>> loadByKeysOrdered(List<K> keys, DBQuery<K, V> dbFunction) {
+        var dbResult = dbFunction.callDBMethod(dslContext, new HashSet<>(keys), select);
+        var orderedResult = keys.stream().map(dbResult::get).toList();
+        return CompletableFuture.completedFuture(orderedResult);
     }
 
     /**

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_nested_java_record-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_nested_java_record-1.result.approved.json
@@ -5,9 +5,15 @@
                 "address": {
                     "id": "QWRkcmVzczoxNA"
                 },
-                "customer": {
-                    "id": "Q3VzdG9tZXI6Ng"
-                },
+                "customers": [
+                    {
+                        "id": "Q3VzdG9tZXI6Ng"
+                    },
+                    null,
+                    {
+                        "id": "Q3VzdG9tZXI6Mg"
+                    }
+                ],
                 "extraAddress": {
                     "id": "QWRkcmVzczo5"
                 }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_nested_java_record.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_nested_java_record.graphql
@@ -4,7 +4,7 @@
             address {
                 id
             }
-            customer {
+            customers {
                 id
             }
             extraAddress {

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
@@ -5,6 +5,8 @@ import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
 import no.sikt.graphitron.example.service.records.MockUpdateAddressAndCustomerResultRecord;
 import org.jooq.DSLContext;
 
+import java.util.List;
+
 public class MockService {
 
     public MockService(DSLContext context) {
@@ -21,9 +23,11 @@ public class MockService {
         address2.setAddressId(14);
         result.setAddress(address2);
 
-        var customer = new CustomerRecord();
-        customer.setCustomerId(6);
-        result.setCustomer(customer);
+        var customer6 = new CustomerRecord();
+        customer6.setCustomerId(6);
+        var customer2 = new CustomerRecord();
+        customer2.setCustomerId(2);
+        result.setCustomers(List.of(customer6, new CustomerRecord(), customer2));
 
         return result;
     }

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/MockUpdateAddressAndCustomerResultRecord.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/MockUpdateAddressAndCustomerResultRecord.java
@@ -3,9 +3,13 @@ package no.sikt.graphitron.example.service.records;
 import no.sikt.graphitron.example.generated.jooq.tables.records.AddressRecord;
 import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
 
+import java.util.List;
+
 public class MockUpdateAddressAndCustomerResultRecord {
     private AddressRecord myAddress;
     private AddressRecord address;
+    private List<CustomerRecord> customers;
+
 
     public AddressRecord getAddress() {
         return address;
@@ -15,15 +19,13 @@ public class MockUpdateAddressAndCustomerResultRecord {
         this.address = address;
     }
 
-    private CustomerRecord customer;
 
-
-    public CustomerRecord getCustomer() {
-        return customer;
+    public List<CustomerRecord> getCustomers() {
+        return customers;
     }
 
-    public void setCustomer(CustomerRecord customer) {
-        this.customer = customer;
+    public void setCustomers(List<CustomerRecord> customers) {
+        this.customers = customers;
     }
 
     public AddressRecord getMyAddress() {

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
@@ -16,7 +16,7 @@ type MockUpdateAddressAndCustomerPayload {
 }
 
 type MockUpdateAddressAndCustomerResult @record(record: {className: "no.sikt.graphitron.example.service.records.MockUpdateAddressAndCustomerResultRecord"}) {
-    customer: Customer @splitQuery
+    customers: [Customer] @splitQuery
     address: Address @splitQuery
     extraAddress: Address @field(name: "myAddress") @splitQuery
 }


### PR DESCRIPTION
Trodde dette ikke var nødvendig med det første, men så viste det seg å være nødvendig for å få utdanningsregisteret på ny Graphitron versjon.
Jeg har gått for å generere spørringer som fungerer ganske likt som lookup-spørringer, sånn at vi beholder rekkefølgen på listen fra servicen.