### PR TITLE
GG-266 split query from single table interface

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/SingleTableInterfaceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/SingleTableInterfaceTest.java
@@ -125,4 +125,25 @@ public class SingleTableInterfaceTest extends InterfaceTest {
 
         );
     }
+
+    @Test
+    @DisplayName("With splitQuery reference in interface")
+    void splitQueryReferenceInInterface() {
+        assertGeneratedContentContains("splitQueryReferenceInInterface",
+                "DSL.row(_address.ADDRESS_ID).as(\"address_pkey\")",
+                " _data.setCustomerKey(internal_it_.get(\"address_pkey\", Record1.class).valuesRow())"
+
+        );
+    }
+
+    @Test
+    @DisplayName("With splitQuery reference in type")
+    void splitQueryReferenceInType() {
+        assertGeneratedContentContains("splitQueryReferenceInType",
+                "DSL.row(_address.ADDRESS_ID).as(\"address_pkey\")",
+                "AddressInDistrictOne.class); _data.setCustomerKey(internal_it_.get(\"address_pkey\"",
+                "return internal_it_.into(AddressInDistrictTwo.class);"
+
+        );
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/singleTableInterface/splitQueryReferenceInInterface/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/singleTableInterface/splitQueryReferenceInInterface/schema.graphqls
@@ -1,0 +1,18 @@
+type Query {
+  address: [Address]
+}
+
+interface Address @table(name: "ADDRESS") @discriminate(on: "DISTRICT"){
+  postalCode: String @field(name: "POSTAL_CODE")
+  customer: Customer @splitQuery
+}
+
+type AddressInDistrictOne implements Address @table(name: "ADDRESS") @discriminator(value: "ONE") {
+    postalCode: String @field(name: "POSTAL_CODE")
+    customer: Customer @splitQuery
+}
+
+type AddressInDistrictTwo implements Address @table(name: "ADDRESS") @discriminator(value: "TWO") {
+    postalCode: String @field(name: "POSTAL_CODE")
+    customer: Customer @splitQuery
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/singleTableInterface/splitQueryReferenceInType/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/singleTableInterface/splitQueryReferenceInType/schema.graphqls
@@ -1,0 +1,16 @@
+type Query {
+  address: [Address]
+}
+
+interface Address @table(name: "ADDRESS") @discriminate(on: "DISTRICT"){
+  postalCode: String @field(name: "POSTAL_CODE")
+}
+
+type AddressInDistrictOne implements Address @table(name: "ADDRESS") @discriminator(value: "ONE") {
+    postalCode: String @field(name: "POSTAL_CODE")
+    customer: Customer @splitQuery
+}
+
+type AddressInDistrictTwo implements Address @table(name: "ADDRESS") @discriminator(value: "TWO") {
+    postalCode: String @field(name: "POSTAL_CODE")
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_single_table_interface-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_in_single_table_interface-1.result.approved.json
@@ -1,0 +1,20 @@
+{
+    "data": {
+        "addressesByPostalCode": {
+            "nodes": [
+                {
+                    "id": "QV8xOjIyMQ",
+                    "city": {
+                        "id": "Q2l0eVR5cGU6NDQ4"
+                    }
+                },
+                {
+                    "id": "QV8yOjMxMw",
+                    "city": {
+                        "id": "Q2l0eVR5cGU6MjYy"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_type_implementing_single_table_interface-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_type_implementing_single_table_interface-1.result.approved.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "addressesByPostalCode": {
+            "nodes": [
+                {
+                    "__typename": "AddressInOneArea",
+                    "id": "QV8xOjIyMQ",
+                    "customers": [
+                        {
+                            "id": "Q3VzdG9tZXI6MjE3"
+                        }
+                    ]
+                },
+                {
+                    "__typename": "AddressInAnotherArea"
+                },
+                {
+                    "__typename": "AddressInAnotherArea"
+                },
+                {
+                    "__typename": "AddressInOneArea",
+                    "id": "QV8xOjU5NQ",
+                    "customers": [
+                        {
+                            "id": "Q3VzdG9tZXI6NTg5"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_single_table_interface.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_in_single_table_interface.graphql
@@ -1,0 +1,15 @@
+{
+    addressesByPostalCode(first: 2) {
+        nodes {
+            ... on AddressInOneArea {
+                id
+            }
+            ... on AddressInAnotherArea {
+                id
+            }
+            city {
+                id
+            }
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_type_implementing_single_table_interface.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_type_implementing_single_table_interface.graphql
@@ -1,0 +1,13 @@
+{
+    addressesByPostalCode(first: 4) {
+        nodes {
+            __typename
+            ... on AddressInOneArea {
+                id
+                customers {
+                    id
+                }
+            }
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/singleTableInterface.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/singleTableInterface.graphql
@@ -5,12 +5,15 @@ extend type Query {
 interface AddressByPostalCode @table(name: "ADDRESS") @discriminate(on: "POSTAL_CODE") {
     mostSignificantAddressLine: String @field(name: "ADDRESS_")
     spokenLanguage: Language @reference(path: [{condition: {className: "no.sikt.graphitron.example.service.conditions.LanguageConditions", method: "spokenLanguageForAddressByPostalCode"}}])
+    city: City @splitQuery
 }
 
 type AddressInOneArea implements AddressByPostalCode & Node @node(typeId: "A_1", keyColumns: "ADDRESS_ID") @table(name: "ADDRESS") @discriminator(value: "22474") {
     id: ID!
     mostSignificantAddressLine: String @field(name: "ADDRESS_")
     spokenLanguage: Language @reference(path: [{condition: {className: "no.sikt.graphitron.example.service.conditions.LanguageConditions", method: "spokenLanguageForAddressByPostalCode"}}])
+    city: City @splitQuery
+    customers: [Customer] @splitQuery
 }
 
 type AddressInAnotherArea implements AddressByPostalCode & Node @node(typeId: "A_2") @table(name: "ADDRESS") @discriminator(value: "9668") {
@@ -18,4 +21,5 @@ type AddressInAnotherArea implements AddressByPostalCode & Node @node(typeId: "A
     spokenLanguage: Language @reference(path: [{condition: {className: "no.sikt.graphitron.example.service.conditions.LanguageConditions", method: "spokenLanguageForAddressByPostalCode"}}])
     mostSignificantAddressLine: String @field(name: "ADDRESS2")
     postalCode: String @field(name: "POSTAL_CODE")
+    city: City @splitQuery
 }


### PR DESCRIPTION
Skal fikse feilen i splitQuery felt fra single table interface queries (som gjorde at vi måtte [rulle tilbake ny graphitron versjon i sis-grafen](https://sikt.atlassian.net/wiki/x/AQAR7Q))


Jeg prøvde også å legge til noen splitQuery felt for multitabellspørringer, og ser at det også ikke fungerer som det skal. Lager ny MR på det sånn at vi har en fiks før vi lager ny release.