### PR TITLE
GG-243 throw validation error on invalid nodeId in jooq Record input

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -244,6 +244,7 @@ public class ProcessedDefinitionsValidator {
                         jooqRecordInput.getFields()
                                 .stream()
                                 .filter(FieldSpecification::hasNodeID)
+                                .filter(it -> schema.isObject(it.getNodeIdTypeName())) // This is validated in checkNodeId
                                 .filter(it -> !schema.getRecordType(it.getNodeIdTypeName()).getTable().equals(jooqRecordInput.getTable()))
                                 .forEach(field -> {
                                     var foreignKeyOptional = getForeignKeyForNodeIdReference(field, schema);

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/NodeIdInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/NodeIdInputTest.java
@@ -25,6 +25,15 @@ public class NodeIdInputTest extends ValidationTest {
     }
 
     @Test
+    @DisplayName("Type provided in jOOQ record input field does not exist")
+    void typeDoesNotExistInJooqRecordInput() {
+        assertErrorsContain(
+                () -> getProcessedSchema("typeDoesNotExistInJooqRecordInput", Set.of(CUSTOMER_NODE)),
+                "Type with name 'DoesNotExist' referenced in the nodeId directive for field CustomerInput.someId does not exist."
+        );
+    }
+
+    @Test
     @DisplayName("Type does not have the @node directive")
     void typeDoesNotHaveNodeDirective() {
         assertErrorsContain(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/nodeId/input/typeDoesNotExistInJooqRecordInput/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/nodeId/input/typeDoesNotExistInJooqRecordInput/schema.graphqls
@@ -1,0 +1,8 @@
+type Query {
+  query(input: CustomerInput): CustomerNode
+}
+
+
+input CustomerInput @table(name: "CUSTOMER") {
+    someId: ID @nodeId(typeName: "DoesNotExist")
+}


### PR DESCRIPTION
Uten endringen her får vi heller `NullPointerException` i `validateNodeIdReferenceInJooqRecordInput`