### PR TITLE
GG-245 fix NullPointerException when returning a list of regular ID fields after mutation

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -834,7 +834,10 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
     private CodeBlock unpackElement(FetchContext context, String argumentInputFieldName, InputCondition condition, JOOQMapping table) {
         var field = condition.getInput();
         if (processedSchema.isNodeIdField(field)) {
-            return hasIdBlock(CodeBlock.of("$N", VARIABLE_INTERNAL_ITERATION), context.getReferenceObject(), context.getTargetAlias());
+            var referenceObject = processedSchema.hasJOOQRecord(field.getContainerTypeName())
+                    ? processedSchema.getRecordType(field.getNodeIdTypeName())
+                    : context.getReferenceObject();
+            return hasIdBlock(CodeBlock.of("$N", VARIABLE_INTERNAL_ITERATION), referenceObject, context.getTargetAlias());
         }
 
         if (!condition.hasRecord()) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/StrategyNodeInterfaceTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/StrategyNodeInterfaceTest.java
@@ -68,6 +68,14 @@ public class StrategyNodeInterfaceTest extends GeneratorTest {
     }
 
     @Test
+    @DisplayName("Querying a list of regular ID fields after mutation")
+    void listedIdFieldAfterMutation() {
+        assertGeneratedContentContains("listedIdFieldAfterMutation", Set.of(CUSTOMER_NODE),
+                "DSL.multiset(DSL.select(_customer.CUSTOMER_ID)"
+        );
+    }
+
+    @Test
     @DisplayName("Multiple fields")
     void manyFields() {
         assertGeneratedContentContains("manyFields", "_customer.FIRST_NAME", "_customer.LAST_NAME");

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/listedIdFieldAfterMutation/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/interfaces/strategynode/listedIdFieldAfterMutation/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+    customer(in: [CustomerInput]): Output @mutation(typeName: DELETE)
+}
+
+type Output {
+    id: [ID] @field(name: "CUSTOMER_ID")
+}
+
+input CustomerInput @table(name: "Customer") {
+    id: ID @nodeId(typeName: "CustomerNode")
+}


### PR DESCRIPTION

Ideelt sett burde vi hatt validering som stopper bygget hvis en kolonne ikke eksisterer, men det bør løses ordentlig i [GG-262](https://sikt.atlassian.net/browse/GG-262).

Her har jeg derfor heller fokusert på å få Graphitron til å generere koden som om kolonnen eksisterer (som vi ellers gjør), så man i det minste får en mer forståelig kompileringsfeil enn en `NullPointerException`.