### PR TITLE
GG-278 Only use the first ID for mutation fetch.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
@@ -1,0 +1,54 @@
+package no.sikt.graphitron.queries.edit;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
+
+@DisplayName("Mutation inputs - Input handling for mutation fetch queries")
+public class MutationInputTest extends GeneratorTest {
+    @Override
+    protected String getSubpath() {
+        return "queries/edit";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new MapOnlyFetchDBClassGenerator(schema));
+    }
+
+    @Test
+    @DisplayName("Mutation has multiple inputs but uses only the first ID")
+    void multipleInputs() {
+        assertGeneratedContentContains(
+                "multipleInputs",
+                "from(_customer)" +
+                        ".where(_customer.hasIds(inRecordList.stream().map(it -> it.getId()).collect(Collectors.toSet())))" +
+                        ".orderBy(orderFields)"
+        );
+    }
+
+    @Test
+    @DisplayName("Mutation has multiple ids but uses only the first ID")
+    void multipleIDs() {
+        assertGeneratedContentContains(
+                "multipleIDs",
+                "from(_customer)" +
+                        ".where(_customer.hasIds(inRecordList.stream().map(it -> it.getId()).collect(Collectors.toSet())))" +
+                        ".orderBy"
+        );
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleIDs/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleIDs/schema.graphqls
@@ -1,0 +1,8 @@
+type Mutation {
+    mutation(in: [CustomerInput!]!): [CustomerTable!]! @mutation(typeName: UPDATE)
+}
+
+input CustomerInput @table(name: "CUSTOMER") {
+    id: ID
+    storeId: ID @field(name: "STORE_ID")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleInputs/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleInputs/schema.graphqls
@@ -1,0 +1,8 @@
+type Mutation {
+    mutation(in: [CustomerInput!]!): [CustomerTable!]! @mutation(typeName: UPDATE)
+}
+
+input CustomerInput @table(name: "CUSTOMER") {
+    id: ID
+    firstName: String @field(name: "FIRST_NAME")
+}


### PR DESCRIPTION
This should alleviate the issue where multiple inputs are used in fetches after mutations.