### PR TITLE
GG-278 Use mutationKey-directive to filter which fields to fetch result with.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/InputField.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/InputField.java
@@ -7,22 +7,21 @@ import no.sikt.graphitron.definitions.objects.InputDefinition;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static no.sikt.graphql.directives.GenerationDirective.LOOKUP_KEY;
-import static no.sikt.graphql.directives.GenerationDirective.ORDER_BY;
+import static no.sikt.graphql.directives.GenerationDirective.*;
 
 /**
  * A field for a {@link InputDefinition}.
  */
 public class InputField extends GenerationSourceField<InputValueDefinition> {
     private final String defaultValue;
-    private final boolean isLookupKey;
-    private final boolean isOrderField;
+    private final boolean isLookupKey, isMutationKey, isOrderField;
 
     public InputField(InputValueDefinition field, String container) {
         super(field, new FieldType(field.getType()), container);
         defaultValue = field.getDefaultValue() != null ? field.getDefaultValue().toString() : "";
 
         isLookupKey = field.hasDirective(LOOKUP_KEY.getName());
+        isMutationKey = field.hasDirective(MUTATION_KEY.getName());
         isOrderField = field.hasDirective(ORDER_BY.getName());
     }
 
@@ -45,6 +44,13 @@ public class InputField extends GenerationSourceField<InputValueDefinition> {
      */
     public boolean isLookupKey() {
         return isLookupKey;
+    }
+
+    /**
+     * @return Is this input field to be used as a key for a mutation result?
+     */
+    public boolean isMutationKey() {
+        return isMutationKey;
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -46,6 +46,7 @@ import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.context.JooqRecordReferenceHelpers.getSourceFieldsForForeignKey;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
 import static no.sikt.graphitron.mappings.TableReflection.*;
+import static no.sikt.graphql.naming.GraphQLReservedName.SCHEMA_MUTATION;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -755,7 +756,11 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         var tupleFieldBlocks = new ArrayList<CodeBlock>();
         var tupleVariableBlocks = new ArrayList<CodeBlock>();
 
-        for (var condition : conditions) {
+        var filteredConditions = context.getReferenceObjectField().getContainerTypeName().equals(SCHEMA_MUTATION.getName()) && conditions.stream().anyMatch(it -> it.getInput().isMutationKey())
+                ? conditions.stream().filter(it -> it.getInput().isMutationKey()).toList()
+                : conditions;
+
+        for (var condition : filteredConditions) {
             var field = condition.getInput();
             var fieldSequence = context.iterateJoinSequenceFor(field);
             var lastTable = fieldSequence.getLast().getTable();

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
@@ -1,0 +1,44 @@
+package no.sikt.graphitron.queries.edit;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
+
+@DisplayName("Mutation inputs - Input handling for mutation fetch queries")
+public class MutationInputTest extends GeneratorTest {
+    @Override
+    protected String getSubpath() {
+        return "queries/edit";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new MapOnlyFetchDBClassGenerator(schema));
+    }
+
+    @Test
+    @DisplayName("Mutation has multiple inputs but uses only the first ID")
+    void multipleInputs() {
+        assertGeneratedContentContains("multipleInputs", "->DSL.row(_customer.hasId(internal_it_.getId())))");
+    }
+
+    @Test
+    @DisplayName("Mutation has multiple ids but uses only the first ID")
+    void multipleIDs() {
+        assertGeneratedContentContains("multipleIDs", "->DSL.row(_customer.hasId(internal_it_.getId())))");
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleIDs/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleIDs/schema.graphqls
@@ -1,0 +1,8 @@
+type Mutation {
+    mutation(in: [CustomerInput!]!): [CustomerTable!]! @mutation(typeName: UPDATE)
+}
+
+input CustomerInput @table(name: "CUSTOMER") {
+    id: ID @mutationKey
+    storeId: ID @field(name: "STORE_ID")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleInputs/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/multipleInputs/schema.graphqls
@@ -1,0 +1,8 @@
+type Mutation {
+    mutation(in: [CustomerInput!]!): [CustomerTable!]! @mutation(typeName: UPDATE)
+}
+
+input CustomerInput @table(name: "CUSTOMER") {
+    id: ID @mutationKey
+    firstName: String @field(name: "FIRST_NAME")
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/directives/GenerationDirective.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/directives/GenerationDirective.java
@@ -18,6 +18,7 @@ public enum GenerationDirective {
     ERROR("error", EnumSet.of(GenerationDirectiveParam.HANDLERS)),
     MUTATION("mutation", EnumSet.of(GenerationDirectiveParam.TYPE)),
     LOOKUP_KEY("lookupKey"),
+    MUTATION_KEY("mutationKey"),
     REFERENCE("reference", EnumSet.of(GenerationDirectiveParam.PATH)),
     ENUM("enum", EnumSet.of(GenerationDirectiveParam.ENUM)),
     CONDITION("condition", EnumSet.of(GenerationDirectiveParam.CONDITION, GenerationDirectiveParam.OVERRIDE, GenerationDirectiveParam.CONTEXT_ARGUMENTS)),

--- a/graphitron-common/src/main/resources/directives.graphqls
+++ b/graphitron-common/src/main/resources/directives.graphqls
@@ -42,7 +42,7 @@ Context arguments must be added to the GraphQLContext at run-time.
 directive @service(service: ExternalCodeReference!, contextArguments: [String!]) on FIELD_DEFINITION
 
 """
-The @error directive serves to map specific Java exceptions to GraphQL errors.
+Maps specific Java exceptions to GraphQL errors.
 This directive is applied to error types in the schema and accepts a list of
 handlers with parameters, specifying how various exceptions should be mapped.
 """
@@ -146,12 +146,12 @@ directive @fetchByID on FIELD_DEFINITION
 enum MutationType { UPDATE, DELETE, INSERT, UPSERT }
 
 input ExternalCodeReference {
-    name: String @deprecated(reason: "Fases ut til fordel for `class`"),
-    """Navnet på klassen man ønsker å referere til.
+    name: String @deprecated(reason: "Will be replaced with `class`"),
+    """Name of the class to reference.
 
-    Dersom pakken klassen finnes i er importert i `externalReferences` i graphitron-konfigurasjonen så holder det med det forenklede navnet, ellers må det fullstendige navnet (fqcn) oppgis."""
+    If the package is imported in `externalReferences` in the maven configuration, the shortened name will suffice, otherwise the full name (fqcn) is required."""
     className: String
-    """Navnet på metoden man ønsker å referere til."""
+    """Name of the method that should be used."""
     method: String
 }
 
@@ -202,3 +202,11 @@ directive @nodeId(
   """
   typeName: String!
 ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+"""
+Specifies which input fields should be used for fetching mutations results. This should probably be the primary key.
+If this is not specified, all mutation inputs are assumed to be the mutation keys.
+
+This feature is only required when not using nodeId, as without it the primary key columns can not be automatically resolved for IDs.
+"""
+directive @mutationKey on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION


### PR DESCRIPTION
Requires setting the directive on the mutation inputs for the logic to kick in. If none are specified, the mutation result query will do the same as before, using all fields in the query.