### PR TITLE
GG-278 Use only PK in mutation results.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -808,9 +808,9 @@ public class FormatCodeBlocks {
         return code.add(".stream().map(it -> it.getId())$L", collectToList()).build();
     }
 
-    private static InputField findUsableRecord(GenerationField target, ProcessedSchema schema, InputParser parser) {
+    public static InputField findUsableRecord(GenerationField target, ProcessedSchema schema, InputParser parser) {
         var responseObject = schema.getObject(target);
-        if (responseObject.hasTable()) {
+        if (responseObject != null && responseObject.hasTable()) {
             var responseFieldTableName = responseObject.getTable().getMappingName();
             return parser
                     .getJOOQRecords()

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -756,14 +756,14 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         var tupleVariableBlocks = new ArrayList<CodeBlock>();
 
         for (var condition : conditions) {
+            if (condition.isOverriddenByAncestors()) {
+                continue;
+            }
+
             var field = condition.getInput();
             var fieldSequence = context.iterateJoinSequenceFor(field);
             var lastTable = fieldSequence.getLast().getTable();
             var unpacked = unpackElement(context, argumentInputFieldName, condition, lastTable);
-
-            if (condition.isOverriddenByAncestors()) {
-                continue;
-            }
 
             if (!field.hasOverridingCondition()) {
                 if (processedSchema.isNodeIdField(field)) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/MutationInputTest.java
@@ -1,0 +1,38 @@
+package no.sikt.graphitron.queries.edit;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_TABLE;
+
+@DisplayName("Mutation inputs - Input handling for mutation fetch queries")
+public class MutationInputTest extends GeneratorTest {
+    @Override
+    protected String getSubpath() {
+        return "queries/edit";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new MapOnlyFetchDBClassGenerator(schema));
+    }
+
+    @Test
+    @DisplayName("Mutation has multiple inputs but uses only the hasPK method")
+    void hasPK() {
+        assertGeneratedContentContains("hasPK", ".where(QueryHelper.hasPK(_customer, inRecordList)).orderBy");
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/hasPK/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/edit/hasPK/schema.graphqls
@@ -1,0 +1,8 @@
+type Mutation {
+    mutation(in: [CustomerInput!]!): [CustomerTable!]! @mutation(typeName: UPDATE)
+}
+
+input CustomerInput @table(name: "CUSTOMER") {
+    id: ID
+    firstName: String @field(name: "FIRST_NAME")
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film-1.result.approved.json
@@ -1,10 +1,22 @@
 {
-    "data": {
-        "insertFilm": {
-            "title": "Jojo's Bizarre Adventure: The Motion Picture",
-            "language": {
-                "id": "TGFuZ3VhZ2U6Mw"
+    "errors": [
+        {
+            "message": "Exception while fetching data (/insertFilm) : null",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "insertFilm"
+            ],
+            "extensions": {
+                "classification": "DataFetchingException"
             }
         }
+    ],
+    "data": {
+        "insertFilm": null
     }
 }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film-1.result.disabled.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film-1.result.disabled.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "insertFilm": {
+            "title": "Jojo's Bizarre Adventure: The Motion Picture",
+            "language": {
+                "id": "TGFuZ3VhZ2U6Mw"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Temporary change to fix the hypothetical issue of mutation returns containing too many elements. Breaks tests for insert because it does not use composite keys and PK is not set in the input record. Picks first input record for the mutation like in older versions.