### PR TITLE
Adds full implementation of Graphql exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ For more information, see:
 -   [Online documentation](https://graphitron.sikt.no/)
 -   [Code-generator README](./graphitron-codegen-parent/graphitron-java-codegen/README.md) for detailed information on how to configure and use the Graphitron Java Code Generator.
 -   [Schema Transform README](./graphitron-schema-transform/README.md) for information on how to transform GraphQL schemas.
+-   [Common Module README](./graphitron-common/README.md) for exception handling framework and shared utilities.
 -   [Example project README](./graphitron-example/README.md) for an example of how to use Graphitron.

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/exception/ExceptionStrategyConfigurationGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/exception/ExceptionStrategyConfigurationGenerator.java
@@ -42,7 +42,6 @@ public class ExceptionStrategyConfigurationGenerator extends AbstractSchemaClass
     @Override
     public TypeSpec generate(SchemaDefinition schemaDefinition) {
         return getSpec("GeneratedExceptionStrategyConfiguration", List.of())
-                .addAnnotation(SINGLETON.className)
                 .addMethod(createConstructor(schemaDefinition))
                 .build();
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/exception/ExceptionToErrorMappingProviderGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/exception/ExceptionToErrorMappingProviderGenerator.java
@@ -39,7 +39,6 @@ public class ExceptionToErrorMappingProviderGenerator extends AbstractSchemaClas
     @Override
     public TypeSpec generate(SchemaDefinition schemaDefinition) {
         return getSpec("GeneratedExceptionToErrorMappingProvider", List.of())
-                .addAnnotation(SINGLETON.className)
                 .addMethod(createConstructor(schemaDefinition))
                 .build();
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/JavaPoetClassName.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/JavaPoetClassName.java
@@ -1,6 +1,5 @@
 package no.sikt.graphitron.mappings;
 
-import no.sikt.graphitron.javapoet.ClassName;
 import graphql.GraphQLError;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.TypeResolver;
@@ -9,6 +8,7 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
 import no.sikt.graphitron.generators.mapping.TransformerClassGenerator;
+import no.sikt.graphitron.javapoet.ClassName;
 import no.sikt.graphitron.validation.RecordValidator;
 import no.sikt.graphql.NodeIdHandler;
 import no.sikt.graphql.NodeIdStrategy;
@@ -45,7 +45,7 @@ public enum JavaPoetClassName {
     COMPLETABLE_FUTURE(java.util.concurrent.CompletableFuture.class),
     DATA_ACCESS_EXCEPTION(DataAccessException.class),
     DATA_ACCESS_EXCEPTION_CONTENT_TO_ERROR_MAPPING(DataAccessExceptionContentToErrorMapping.class),
-    DATA_ACCESS_EXCEPTION_MAPPING_CONTENT(DataAccessExceptionMappingContent.class),
+    DATA_ACCESS_EXCEPTION_MAPPING_CONTENT(DataAccessMatcher.class),
     DATA_FETCHING_ENVIRONMENT(graphql.schema.DataFetchingEnvironment.class),
     ENVIRONMENT_HANDLER(EnvironmentHandler.class),
     DATA_FETCHER(graphql.schema.DataFetcher.class),
@@ -59,7 +59,7 @@ public enum JavaPoetClassName {
     FUNCTION(java.util.function.Function.class),
     FUNCTIONS(org.jooq.Functions.class),
     GENERIC_EXCEPTION_CONTENT_TO_ERROR_MAPPING(GenericExceptionContentToErrorMapping.class),
-    GENERIC_EXCEPTION_MAPPING_CONTENT(GenericExceptionMappingContent.class),
+    GENERIC_EXCEPTION_MAPPING_CONTENT(GenericExceptionMatcher.class),
     GRAPHQL_ERROR(GraphQLError.class),
     HASH_MAP(java.util.HashMap.class),
     HASH_SET(java.util.HashSet.class),
@@ -86,7 +86,6 @@ public enum JavaPoetClassName {
     RESOLVER_HELPERS(ResolverHelpers.class),
     SELECTION_SET(SelectionSet.class),
     SET(java.util.Set.class),
-    SINGLETON(javax.inject.Singleton.class),
     STRING(java.lang.String.class),
     THROWABLE(Throwable.class),
     VALIDATION_VIOLATION_EXCEPTION(ValidationViolationGraphQLException.class),

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/exceptionhandling/ProviderTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/exceptionhandling/ProviderTest.java
@@ -79,7 +79,7 @@ public class ProviderTest extends GeneratorTest {
     void withMatches() {
         assertGeneratedContentContains(
                 "withMatches", Set.of(MUTATION_RESPONSE),
-                "GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", \"MATCH\""
+                "GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", \"MATCH\""
         );
     }
 
@@ -115,9 +115,9 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "multipleHandlers", Set.of(MUTATION_RESPONSE),
                 "m1 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError",
                 "m2 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalStateException\", null),(path, msg) -> new SomeError",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalStateException\", null),(path, msg) -> new SomeError",
                 "List.of(m1, m2)"
         );
     }
@@ -154,7 +154,7 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "databaseHandledError", Set.of(MUTATION_RESPONSE),
                 "m1 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError(",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError(",
                 "mutationDatabaseList = List.of(m1)",
                 "dataAccessMappingsForOperation.put(\"mutation\", mutationDatabaseList"
         );
@@ -166,9 +166,9 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "multipleDatabaseHandlers", Set.of(MUTATION_RESPONSE),
                 "m1 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(\"C_0\", null),(path, msg) -> new SomeError",
+                        "new DataAccessMatcher(\"C_0\", null),(path, msg) -> new SomeError",
                 "m2 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(\"C_1\", null),(path, msg) -> new SomeError",
+                        "new DataAccessMatcher(\"C_1\", null),(path, msg) -> new SomeError",
                 "List.of(m1, m2)"
         );
     }
@@ -178,7 +178,7 @@ public class ProviderTest extends GeneratorTest {
     void databaseWithCode() {
         assertGeneratedContentContains(
                 "databaseWithCode", Set.of(MUTATION_RESPONSE),
-                "DataAccessExceptionMappingContent(\"CODE\","
+                "DataAccessMatcher(\"CODE\","
         );
     }
 
@@ -187,7 +187,7 @@ public class ProviderTest extends GeneratorTest {
     void databaseWithMatches() {
         assertGeneratedContentContains(
                 "databaseWithMatches", Set.of(MUTATION_RESPONSE),
-                "DataAccessExceptionMappingContent(null, \"MATCHES\")"
+                "DataAccessMatcher(null, \"MATCHES\")"
         );
     }
 
@@ -209,13 +209,13 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "bothGenericAndDatabaseInMultipleErrorsForOneResponse", Set.of(MUTATION_RESPONSE),
                 "m1 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError0",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError0",
                 "m2 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
                 "m3 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError1",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError1",
                 "m4 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError1",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError1",
                 "mutationDatabaseList = List.of(m1)",
                 "mutationGenericList = List.of(m2)",
                 "mutationDatabaseList = List.of(m3)",
@@ -279,9 +279,9 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "unionMultipleMixedHandlers", Set.of(MUTATION_RESPONSE),
                 "m1 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError1",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError1",
                 "m2 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
                 "mutationDatabaseList = List.of(m1)",
                 "mutationGenericList = List.of(m2)"
         );
@@ -293,13 +293,13 @@ public class ProviderTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "unionMultipleErrorsWithMultipleMixedHandlers", Set.of(MUTATION_RESPONSE),
                 "m1 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError0",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError0",
                 "m2 = new DataAccessExceptionContentToErrorMapping(" +
-                        "new DataAccessExceptionMappingContent(null, null),(path, msg) -> new SomeError1",
+                        "new DataAccessMatcher(null, null),(path, msg) -> new SomeError1",
                 "m3 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError0",
                 "m4 = new GenericExceptionContentToErrorMapping(" +
-                        "new GenericExceptionMappingContent(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError1",
+                        "new GenericExceptionMatcher(\"java.lang.IllegalArgumentException\", null),(path, msg) -> new SomeError1",
                 "mutationDatabaseList = List.of(m1, m2)",
                 "mutationGenericList = List.of(m3, m4)"
         );

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/configuration/default/expected/GeneratedExceptionStrategyConfiguration.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/configuration/default/expected/GeneratedExceptionStrategyConfiguration.java
@@ -14,9 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import no.sikt.graphql.exception.ExceptionStrategyConfiguration;
 import no.sikt.graphql.exception.ValidationViolationGraphQLException;
-import javax.inject.Singleton;
 
-@Singleton
 public class GeneratedExceptionStrategyConfiguration implements ExceptionStrategyConfiguration {
     private final Map<Class<? extends Throwable>, Set<String>> fieldsForException;
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/configuration/query/expected/GeneratedExceptionStrategyConfiguration.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/configuration/query/expected/GeneratedExceptionStrategyConfiguration.java
@@ -14,9 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import no.sikt.graphql.exception.ExceptionStrategyConfiguration;
 import no.sikt.graphql.exception.ValidationViolationGraphQLException;
-import javax.inject.Singleton;
 
-@Singleton
 public class GeneratedExceptionStrategyConfiguration implements ExceptionStrategyConfiguration {
     private final Map<Class<? extends Throwable>, Set<String>> fieldsForException;
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/provider/default/expected/GeneratedExceptionToErrorMappingProvider.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/exceptions/provider/default/expected/GeneratedExceptionToErrorMappingProvider.java
@@ -6,13 +6,11 @@ import java.lang.String;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.inject.Singleton;
 import no.sikt.graphql.exception.DataAccessExceptionContentToErrorMapping;
 import no.sikt.graphql.exception.ExceptionToErrorMappingProvider;
 import no.sikt.graphql.exception.GenericExceptionContentToErrorMapping;
-import no.sikt.graphql.exception.GenericExceptionMappingContent;
+import no.sikt.graphql.exception.GenericExceptionMatcher;
 
-@Singleton
 public class GeneratedExceptionToErrorMappingProvider implements ExceptionToErrorMappingProvider {
     private final Map<String, List<DataAccessExceptionContentToErrorMapping>> dataAccessMappingsForOperation;
 
@@ -22,7 +20,7 @@ public class GeneratedExceptionToErrorMappingProvider implements ExceptionToErro
         dataAccessMappingsForOperation = new HashMap<>();
         genericMappingsForOperation = new HashMap<>();
         var m1 = new GenericExceptionContentToErrorMapping(
-                new GenericExceptionMappingContent("java.lang.IllegalArgumentException", null),
+                new GenericExceptionMatcher("java.lang.IllegalArgumentException", null),
                 (path, msg) -> new SomeError(path, msg));
 
         var mutationGenericList = List.of(m1);

--- a/graphitron-common/README.md
+++ b/graphitron-common/README.md
@@ -1,0 +1,305 @@
+# Graphitron Common Module
+
+Shared utilities and components for the Graphitron framework, including the exception handling framework, GraphQL helpers, and servlet utilities.
+
+## Exception Handling Framework
+
+Transforms Java exceptions into GraphQL-compliant error responses with user-friendly messages. The framework supports both **Top-Level Errors** (in the GraphQL response's `errors` array) and **Ad Hoc Error Fields** (errors as part of your schema).
+
+### Top-Level Errors vs Ad Hoc Error Fields
+
+#### Top-Level Errors
+Top-level errors appear in the standard GraphQL `errors` array at the root of the response. These are best for:
+- **Technical/exceptional issues**: Network problems, authentication failures, rate limiting
+- **Developer errors**: Malformed queries, missing required arguments
+- **System failures**: Database offline, service unavailable
+- **Unhandled exceptions**: Unexpected runtime errors
+
+Example response with top-level error (from approval tests):
+```json
+{
+  "errors": [
+    {
+      "message": "An exception occurred. The error has been logged with id [UUID].",
+      "locations": [{"line": 2, "column": 5}],
+      "path": ["allCustomerEmails_topLevelError"],
+      "extensions": {
+        "classification": "DataFetchingException"
+      }
+    }
+  ],
+  "data": {
+    "allCustomerEmails_topLevelError": null
+  }
+}
+```
+
+#### Ad Hoc Error Fields (Schema-Based Errors)
+Ad hoc error fields are part of your GraphQL schema, typically in mutation payloads. These are best for:
+- **Business logic errors**: Validation failures, constraint violations
+- **User-facing errors**: Form validation, duplicate entries, invalid input
+- **Expected error conditions**: Part of normal application flow
+- **Partial success scenarios**: Some operations succeed while others fail
+
+Example schema with ad hoc errors:
+```graphql
+type FilmMutationPayload {
+    errors: [Error!]  # Ad hoc error field
+    film: Film        # Can be returned even if errors exist
+}
+```
+
+Example response with ad hoc error (from approval tests):
+```json
+{
+  "data": {
+    "updateFilmReleaseYear_handledError": {
+      "errors": [
+        {
+          "__typename": "InvalidInput",
+          "message": "Release year must be between 1901 and 2155",
+          "path": ["updateFilmReleaseYear_handledError"]
+        }
+      ],
+      "film": null
+    }
+  }
+}
+```
+
+### Architecture Overview
+
+```
+GraphQL Execution
+       ↓
+CustomExecutionStrategy (intercepts exceptions)
+       ↓
+SchemaBasedErrorStrategy (attempts schema-based handling)
+       ↓
+SchemaErrorMapper (maps to schema errors) OR TopLevelErrorHandler (creates top-level errors)
+       ↓
+Error Payload (returned to client)
+```
+
+### How Graphitron Handles Both Error Types
+
+The framework intelligently routes exceptions to either schema-based (ad hoc) errors or top-level errors:
+
+1. **Schema-Based Errors (when configured)**: If an exception occurs in a field that returns a payload with an `errors` field, and the exception matches your `@error` directive configuration, it becomes a schema-based error
+2. **Top-Level Errors (fallback)**: All other exceptions become top-level errors, including unmatched exceptions and exceptions in fields without error payloads
+
+### Core Components
+
+#### 1. CustomExecutionStrategy
+- **Purpose**: Intercepts exceptions during field resolution and determines error type
+- **Routes to Schema-Based**: When SchemaBasedErrorStrategy can handle the exception
+- **Routes to Top-Level**: When exception is unrecognized or field has no error payload
+
+#### 2. SchemaBasedErrorStrategy
+- **Purpose**: Manages schema-based error handling for configured operations
+- **Function**: Checks if exception matches `@error` directives and creates payload with errors array
+
+#### 3. SchemaErrorMapper
+- **Purpose**: Maps exceptions to schema-based error objects
+- **Function**: Matches database/business logic exceptions to appropriate error types
+
+#### 4. TopLevelErrorHandler
+- **Purpose**: Handles top-level errors for unrecognized exceptions
+- **Function**: Logs with unique IDs and creates standard GraphQL errors
+
+### Generated Components
+
+Graphitron generates exception handling code based on your GraphQL schema `@error` directives:
+
+#### Generated Classes
+- **GeneratedExceptionStrategyConfiguration**: Maps operations to exception types they handle
+- **GeneratedExceptionToErrorMappingProvider**: Provides exception-to-error mappings per operation
+- **ExceptionStrategyImpl**: Your custom implementation extending SchemaBasedErrorStrategy
+- **Error type classes**: Java classes for each error type defined in the schema
+
+These classes are generated in the `target/generated-sources` directory when you run `mvn graphitron:generate-code`.
+
+### Exception Mapping System
+
+The framework uses a two-tier mapping system:
+
+#### 1. Matchers
+Determine if an exception matches specific criteria:
+
+- **GenericExceptionMatcher**: Matches exceptions by class type and optional message substring
+- **DataAccessMatcher**: Extends GenericExceptionMatcher to also match SQL error codes
+
+#### 2. Content-to-Error Mappings
+Handle matched exceptions and create error objects:
+
+- **ExceptionContentToErrorMapping**: Base interface for all mappings
+- **GenericExceptionContentToErrorMapping**: Maps business logic exceptions
+- **DataAccessExceptionContentToErrorMapping**: Maps database exceptions
+
+### Special Exception Types
+
+#### ValidationViolationGraphQLException
+- **Purpose**: Thrown when Jakarta Bean Validation fails
+- **Contains**: Field-level validation errors
+- **Usage**: Automatically created when validation constraints are violated
+
+### Exception Routing Flow
+
+When an exception occurs during field resolution:
+
+1. `CustomExecutionStrategy` intercepts the exception
+2. Passes to `SchemaBasedErrorStrategy` to check for `@error` directive matches
+3. **If matched → Schema-Based Error**:
+   - `SchemaErrorMapper` creates error object based on `@error` configuration
+   - Returns payload with populated `errors` array
+   - Response has data with errors, no top-level errors
+4. **If not matched → Top-Level Error**:
+   - Falls back to `TopLevelErrorHandler`
+   - Logs exception with unique ID
+   - Response has null data with top-level errors array
+
+### Schema-Driven Generation
+
+Define error types in your GraphQL schema with `@error` directives:
+
+```graphql
+interface Error {
+    path: [String!]!
+    message: String!
+}
+
+type InvalidInput implements Error @error(handlers: [
+    {
+        handler: DATABASE, 
+        code: "23514", 
+        matches: "year_check", 
+        description: "Release year must be between 1901 and 2155"
+    },
+    {
+        handler: BUSINESS_LOGIC,
+        className: "java.lang.IllegalArgumentException",
+        matches: "invalid year",
+        description: "Invalid year provided"
+    }
+]) {
+    path: [String!]!
+    message: String!
+}
+
+type FilmMutationPayload {
+    errors: [Error!]
+    film: Film
+}
+
+type Mutation {
+    createFilm(input: FilmInput!): FilmMutationPayload
+}
+```
+
+When you run `mvn graphitron:generate-code`, Graphitron generates:
+- Error type classes (e.g., `InvalidInput.java`)
+- Payload classes with errors field (e.g., `FilmMutationPayload.java`)
+- Exception configuration mapping these errors to operations
+- Resolver/Datafetcher methods that automatically use the exception handling
+
+### Implementation Setup
+
+See the [graphitron-example-server](../graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/server/GraphqlServlet.java) for a complete implementation.
+
+Use the `ExceptionHandlingBuilder` to configure exception handling:
+
+```java
+private static ExecutionStrategy getCustomExecutionStrategy() {
+    var dataAccessMapper = new DataAccessExceptionMapperImpl();
+    var configuration = new GeneratedExceptionStrategyConfiguration();
+    var mappingProvider = new GeneratedExceptionToErrorMappingProvider();
+    
+    return ExceptionHandlingBuilder.create()
+        .withDataAccessMapper(dataAccessMapper)
+        .withSchemaBasedStrategy(new SchemaBasedErrorStrategyImpl(
+            configuration,
+            mappingProvider,
+            dataAccessMapper
+        ))
+        .build();
+}
+
+// In your servlet or GraphQL setup:
+GraphQL graphQL = GraphQL.newGraphQL(schema)
+    .queryExecutionStrategy(getCustomExecutionStrategy())
+    .mutationExecutionStrategy(getCustomExecutionStrategy())
+    .build();
+```
+
+You can provide your own implementation of `DataAccessExceptionMapper` to customize how database exceptions are mapped to user-friendly messages. You can use the `ErrorMessageFormatter` class provided in this module to convert SQL error codes into readable messages.
+
+### Database Error Formatting
+
+The `ErrorMessageFormatter` class provides user-friendly messages for common SQL errors:
+
+| SQL State | Error Type | User Message |
+|-----------|------------|--------------|
+| 23505 | Unique constraint | "Duplicate value not allowed" |
+| 23503 | Foreign key | "Referenced record does not exist" |
+| 23502 | Not null | "Required field cannot be empty" |
+| 23514 | Check constraint | "Value violates constraint: [name]" |
+| 22001 | Data too long | "Value exceeds maximum length" |
+
+For check constraints, the formatter attempts to extract and humanize the constraint name (e.g., "year_check" becomes "year").
+
+### Best Practices
+
+#### When to Use Ad Hoc Errors
+- **Validation failures**: Invalid input that users can fix
+- **Business rule violations**: Duplicate usernames, insufficient balance, etc.
+- **Partial success**: When some operations succeed and others fail
+- **User-actionable errors**: Errors users can understand and resolve
+
+#### When to Use Top-Level Errors
+- **Authentication/Authorization**: Not logged in, insufficient permissions
+- **System failures**: Database offline, service unavailable  
+- **Developer errors**: Malformed queries, type mismatches
+- **Unexpected exceptions**: Null pointers, network timeouts
+
+#### Configuration Tips
+1. **Define all user-facing errors in schema** with `@error` directives
+2. **Let technical errors fall through** to become top-level errors
+3. **Use descriptive error messages** in `@error` descriptions
+4. **Include path information** in error types to help locate issues
+5. **Keep error messages user-friendly** without exposing internals
+
+### Custom Exception Strategy Example
+
+Extend `SchemaBasedErrorStrategy` to handle application-specific exceptions. See [ExceptionStrategyImpl.java](../graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/exceptionhandling/ExceptionStrategyImpl.java) in the example project:
+
+```java
+public class ExceptionStrategyImpl extends SchemaBasedErrorStrategy {
+    
+    @Override
+    protected Object createDefaultDataAccessError(
+            String operationName, 
+            String message) {
+        // Return your default error type for unmatched database exceptions
+        return new GenericDatabaseError(List.of(operationName), message);
+    }
+    
+    @Override
+    protected Object createDefaultBusinessLogicError(
+            String operationName, 
+            String message) {
+        // Return your default error type for unmatched business logic exceptions
+        return new GenericError(List.of(operationName), message);
+    }
+}
+```
+
+## Other Components
+
+### GraphQL Helpers
+- **NodeIdStrategy**: Relay node ID encoding/decoding
+- **QueryHelper**: jOOQ query building utilities
+- **ResolverHelpers**: Data fetching utilities
+
+### Servlet Support
+- **GraphitronServlet**: Base servlet for GraphQL endpoints
+- **GraphitronInstrumentation**: Performance monitoring and logging

--- a/graphitron-common/pom.xml
+++ b/graphitron-common/pom.xml
@@ -68,9 +68,16 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/CustomExecutionStrategy.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/CustomExecutionStrategy.java
@@ -1,0 +1,41 @@
+package no.sikt.graphql.exception;
+
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.ExecutionStrategyParameters;
+import graphql.schema.DataFetchingEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Custom execution strategy that routes exceptions to either schema-based or top-level errors.
+ * <p>
+ * This is the main entry point for exception handling in the GraphQL execution layer.
+ * It first attempts to handle exceptions as schema-based errors (via SchemaBasedErrorStrategy),
+ * and if that's not possible, falls back to top-level errors (via TopLevelErrorHandler).
+ */
+public class CustomExecutionStrategy extends AsyncExecutionStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomExecutionStrategy.class);
+
+    private final SchemaBasedErrorStrategy schemaBasedErrorStrategy;
+
+    public CustomExecutionStrategy(TopLevelErrorHandler topLevelErrorHandler, SchemaBasedErrorStrategy schemaBasedErrorStrategy) {
+        super(topLevelErrorHandler);
+        this.schemaBasedErrorStrategy = schemaBasedErrorStrategy;
+    }
+
+    @Override
+    protected <T> CompletableFuture<T> handleFetchingException(DataFetchingEnvironment environment, ExecutionStrategyParameters parameters, Throwable e) {
+        Optional<CompletableFuture<Object>> schemaBasedResult = schemaBasedErrorStrategy.handleException(environment, e);
+
+        if (schemaBasedResult.isPresent()) {
+            LOGGER.debug("Exception handled as schema-based error:", e);
+            return (CompletableFuture<T>) schemaBasedResult.get();
+        }
+
+        LOGGER.debug("Exception will become top-level error:", e);
+        return super.handleFetchingException(environment, parameters, e);
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionContentToErrorMapping.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionContentToErrorMapping.java
@@ -5,10 +5,10 @@ import org.jooq.exception.DataAccessException;
 import java.util.List;
 
 public class DataAccessExceptionContentToErrorMapping implements ExceptionContentToErrorMapping {
-    final private DataAccessExceptionMappingContent dataAccessExceptionMapping;
+    final private DataAccessMatcher dataAccessExceptionMapping;
     final private ErrorHandler errorHandler;
 
-    public DataAccessExceptionContentToErrorMapping(DataAccessExceptionMappingContent dataAccessExceptionMapping, ErrorHandler errorHandler) {
+    public DataAccessExceptionContentToErrorMapping(DataAccessMatcher dataAccessExceptionMapping, ErrorHandler errorHandler) {
         this.dataAccessExceptionMapping = dataAccessExceptionMapping;
         this.errorHandler = errorHandler;
     }

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionMapper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionMapper.java
@@ -1,0 +1,10 @@
+package no.sikt.graphql.exception;
+
+import org.jooq.exception.DataAccessException;
+
+public interface DataAccessExceptionMapper {
+
+    default String getMsgFromException(DataAccessException exception) {
+        return exception.getMessage();
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionMapperImpl.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessExceptionMapperImpl.java
@@ -1,0 +1,58 @@
+package no.sikt.graphql.exception;
+
+import org.jooq.exception.DataAccessException;
+
+/**
+ * Implementation of DataAccessExceptionMapper that uses ErrorMessageFormatter
+ * to provide consistent and user-friendly error messages for database exceptions.
+ */
+public class DataAccessExceptionMapperImpl implements DataAccessExceptionMapper {
+
+    private final ErrorMessageFormatter formatter;
+    private final boolean includeDebugInfo;
+
+    /**
+     * Create a mapper with default settings (no debug info).
+     */
+    public DataAccessExceptionMapperImpl() {
+        this(new ErrorMessageFormatter(), false);
+    }
+
+    /**
+     * Create a mapper with custom formatter and debug settings.
+     *
+     * @param formatter        The error message formatter to use
+     * @param includeDebugInfo Whether to include technical details in error messages
+     */
+    public DataAccessExceptionMapperImpl(ErrorMessageFormatter formatter, boolean includeDebugInfo) {
+        this.formatter = formatter;
+        this.includeDebugInfo = includeDebugInfo;
+    }
+
+    @Override
+    public String getMsgFromException(DataAccessException exception) {
+        String userMessage = formatter.formatDataAccessException(exception);
+
+        if (includeDebugInfo) {
+            return appendDebugInfo(userMessage, exception);
+        }
+
+        return userMessage;
+    }
+
+    /**
+     * Append debug information to the error message.
+     * Useful in development environments.
+     */
+    private String appendDebugInfo(String message, DataAccessException exception) {
+        StringBuilder debugMessage = new StringBuilder(message);
+
+        var sqlException = exception.getCause(java.sql.SQLException.class);
+        if (sqlException != null) {
+            debugMessage.append(" [SQL State: ").append(sqlException.getSQLState());
+            debugMessage.append(", Error Code: ").append(sqlException.getErrorCode()).append("]");
+        }
+
+        return debugMessage.toString();
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessMatcher.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/DataAccessMatcher.java
@@ -4,10 +4,14 @@ import org.jooq.exception.DataAccessException;
 
 import java.sql.SQLException;
 
-public class DataAccessExceptionMappingContent extends GenericExceptionMappingContent {
+/**
+ * Matcher for DataAccessException that checks both SQL error code and message content.
+ * This class extends GenericExceptionMatcher to add SQL-specific matching logic.
+ */
+public class DataAccessMatcher extends GenericExceptionMatcher {
     private final String errorCode;
 
-    public DataAccessExceptionMappingContent(String errorCode, String substringOfExceptionMessage) {
+    public DataAccessMatcher(String errorCode, String substringOfExceptionMessage) {
         super(DataAccessException.class.getName(), substringOfExceptionMessage);
         this.errorCode = errorCode;
     }

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/ErrorMessageFormatter.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/ErrorMessageFormatter.java
@@ -1,0 +1,86 @@
+package no.sikt.graphql.exception;
+
+import org.jooq.exception.DataAccessException;
+
+import java.sql.SQLException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Simple formatter for database exception error messages.
+ * Provides basic user-friendly messages for common SQL errors.
+ */
+public class ErrorMessageFormatter {
+
+    // Pattern to extract constraint names from database error messages
+    private static final Pattern CONSTRAINT_PATTERN = Pattern.compile(
+            "constraint\\s+[\"']?([^\"'\\s]+)[\"']?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /**
+     * Extract a user-friendly message from a DataAccessException.
+     */
+    public String formatDataAccessException(DataAccessException exception) {
+        SQLException sqlException = exception.getCause(SQLException.class);
+
+        if (sqlException == null || sqlException.getMessage() == null) {
+            return getDefaultMessage(exception);
+        }
+
+        String sqlMessage = sqlException.getMessage();
+        String sqlState = sqlException.getSQLState();
+
+        // Handle common SQL states with simple messages
+        if (sqlState != null) {
+            return switch (sqlState) {
+                case "23505" -> "Duplicate value not allowed";
+                case "23503" -> "Referenced record does not exist";
+                case "23502" -> "Required field cannot be empty";
+                case "23514" -> formatCheckConstraint(sqlMessage);
+                case "22001" -> "Value exceeds maximum length";
+                default -> cleanupMessage(sqlMessage);
+            };
+        }
+
+        return cleanupMessage(sqlMessage);
+    }
+
+    /**
+     * Format check constraint violation - try to extract the constraint name.
+     */
+    private String formatCheckConstraint(String sqlMessage) {
+        Matcher matcher = CONSTRAINT_PATTERN.matcher(sqlMessage);
+        if (matcher.find()) {
+            String constraintName = matcher.group(1);
+            // Simple cleanup: remove common suffixes and convert to readable format
+            String cleaned = constraintName.toLowerCase()
+                    .replaceAll("_check$", "")
+                    .replace('_', ' ');
+            return "Value violates constraint: " + cleaned;
+        }
+        return "Value does not meet validation requirements";
+    }
+
+    /**
+     * Basic cleanup of SQL error messages.
+     */
+    private String cleanupMessage(String message) {
+        // Remove common prefixes and normalize
+        return message
+                .replaceAll("ERROR:\\s*", "")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    /**
+     * Get default message when SQL exception is not available.
+     */
+    private String getDefaultMessage(Throwable exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return "Database operation failed";
+        }
+        return cleanupMessage(message);
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/ExceptionHandlingBuilder.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/ExceptionHandlingBuilder.java
@@ -1,0 +1,73 @@
+package no.sikt.graphql.exception;
+
+import graphql.execution.ExecutionStrategy;
+
+/**
+ * Builder for creating a fully configured exception handling setup for GraphQL Java.
+ * <p>
+ * This builder sets up both schema-based (ad-hoc) and top-level error handling.
+ * Schema-based errors appear in payload "errors" fields, while top-level errors
+ * appear in the GraphQL response's root "errors" array.
+ */
+public class ExceptionHandlingBuilder {
+
+    private DataAccessExceptionMapper dataAccessMapper;
+    private SchemaBasedErrorStrategy schemaBasedStrategy;
+    private TopLevelErrorHandler topLevelErrorHandler;
+
+
+    /**
+     * Set the data access exception mapper.
+     * This mapper extracts messages from database exceptions.
+     */
+    public ExceptionHandlingBuilder withDataAccessMapper(DataAccessExceptionMapper dataAccessMapper) {
+        this.dataAccessMapper = dataAccessMapper;
+        return this;
+    }
+
+    /**
+     * Set the schema-based error strategy implementation.
+     * This handles exceptions that should become errors in payload fields.
+     */
+    public ExceptionHandlingBuilder withSchemaBasedStrategy(SchemaBasedErrorStrategy strategy) {
+        this.schemaBasedStrategy = strategy;
+        return this;
+    }
+
+    /**
+     * Set a custom top-level error handler.
+     * If not set, a default handler will be created using the data access mapper.
+     * This handles exceptions that don't match schema @error directives.
+     */
+    public ExceptionHandlingBuilder withTopLevelErrorHandler(TopLevelErrorHandler handler) {
+        this.topLevelErrorHandler = handler;
+        return this;
+    }
+
+    /**
+     * Build the configured execution strategy.
+     *
+     * @return A CustomExecutionStrategy with all components properly wired
+     * @throws IllegalStateException if required components are not set
+     */
+    public ExecutionStrategy build() {
+        // Validate required components
+        if (schemaBasedStrategy == null) {
+            throw new IllegalStateException(
+                    "Schema-based error strategy must be provided. Call withSchemaBasedStrategy()."
+            );
+        }
+
+        // Create top-level error handler if not provided
+        if (topLevelErrorHandler == null) {
+            if (dataAccessMapper == null) {
+                throw new IllegalStateException(
+                        "Either provide a TopLevelErrorHandler or a DataAccessExceptionMapper to create the default handler."
+                );
+            }
+            topLevelErrorHandler = new TopLevelErrorHandler(dataAccessMapper);
+        }
+
+        return new CustomExecutionStrategy(topLevelErrorHandler, schemaBasedStrategy);
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/GenericExceptionContentToErrorMapping.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/GenericExceptionContentToErrorMapping.java
@@ -3,16 +3,16 @@ package no.sikt.graphql.exception;
 import java.util.List;
 
 public class GenericExceptionContentToErrorMapping implements ExceptionContentToErrorMapping {
-    final private GenericExceptionMappingContent genericExceptionMappingContent;
+    final private GenericExceptionMatcher genericExceptionMatcher;
     final private ErrorHandler errorHandler;
 
-    public GenericExceptionContentToErrorMapping(GenericExceptionMappingContent genericExceptionMappingContent, ErrorHandler errorHandler) {
-        this.genericExceptionMappingContent = genericExceptionMappingContent;
+    public GenericExceptionContentToErrorMapping(GenericExceptionMatcher genericExceptionMatcher, ErrorHandler errorHandler) {
+        this.genericExceptionMatcher = genericExceptionMatcher;
         this.errorHandler = errorHandler;
     }
 
     public boolean matches(Throwable exception) {
-        return genericExceptionMappingContent.matches(exception);
+        return genericExceptionMatcher.matches(exception);
     }
 
     @Override

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/GenericExceptionMatcher.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/GenericExceptionMatcher.java
@@ -4,11 +4,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class GenericExceptionMappingContent {
+/**
+ * Generic matcher for exceptions that checks class type and message content.
+ * Can match against the full exception cause chain.
+ */
+public class GenericExceptionMatcher {
     private final String substringOfExceptionMessage;
     private final String fullyQualifiedClassName;
 
-    public GenericExceptionMappingContent(String fullyQualifiedClassName, String substringOfExceptionMessage) {
+    public GenericExceptionMatcher(String fullyQualifiedClassName, String substringOfExceptionMessage) {
         this.substringOfExceptionMessage = substringOfExceptionMessage;
         this.fullyQualifiedClassName = fullyQualifiedClassName;
     }
@@ -34,5 +38,3 @@ public class GenericExceptionMappingContent {
                 .orElse(true);
     }
 }
-
-

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/SchemaBasedErrorStrategy.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/SchemaBasedErrorStrategy.java
@@ -1,0 +1,114 @@
+package no.sikt.graphql.exception;
+
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import org.jooq.exception.DataAccessException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Strategy for handling exceptions as schema-based (ad-hoc) errors.
+ * <p>
+ * Schema-based errors are part of your GraphQL schema, typically in mutation/query payloads
+ * with an "errors" field. These are used for expected business logic errors like validation
+ * failures, constraint violations, or any errors that users can understand and potentially fix.
+ * <p>
+ * This strategy only handles exceptions that:
+ * 1. Occur in operations that return a payload with an "errors" field
+ * 2. Match the @error directive configuration in the schema
+ * <p>
+ * Exceptions not handled here fall through to become top-level errors.
+ */
+public abstract class SchemaBasedErrorStrategy {
+
+    private final ExceptionStrategyConfiguration configuration;
+    private final SchemaErrorMapper schemaErrorMapper;
+
+    public SchemaBasedErrorStrategy(ExceptionStrategyConfiguration configuration,
+                                    ExceptionToErrorMappingProvider mappingProvider,
+                                    DataAccessExceptionMapper dataAccessExceptionMapper) {
+        this.configuration = configuration;
+        this.schemaErrorMapper = new SchemaErrorMapper(
+                mappingProvider.getDataAccessMappingsForOperation(),
+                mappingProvider.getGenericMappingsForOperation(),
+                dataAccessExceptionMapper
+        );
+    }
+
+    /**
+     * Attempts to handle an exception as a schema-based error.
+     * Returns an Optional containing the error payload if the exception matches schema configuration,
+     * or Optional.empty() if the exception should become a top-level error instead.
+     */
+    public Optional<CompletableFuture<Object>> handleException(DataFetchingEnvironment environment, Throwable thrownException) {
+        String operationName = environment.getFieldDefinition().getName();
+
+        // Check if this exception type is configured for handling
+        for (var entry : configuration.getFieldsForException().entrySet()) {
+            Class<? extends Throwable> exceptionType = entry.getKey();
+            if (exceptionType.isInstance(thrownException) &&
+                    entry.getValue().contains(operationName)) {
+
+                // Delegate to specific handler based on exception type
+                if (thrownException instanceof ValidationViolationGraphQLException) {
+                    return handleValidationException(
+                            (ValidationViolationGraphQLException) thrownException,
+                            operationName);
+                } else if (thrownException instanceof IllegalArgumentException) {
+                    return handleIllegalArgumentException(
+                            (IllegalArgumentException) thrownException,
+                            operationName,
+                            environment.getExecutionStepInfo().getPath());
+                } else if (thrownException instanceof DataAccessException) {
+                    return handleDataAccessException(
+                            (DataAccessException) thrownException,
+                            operationName);
+                } else {
+                    return handleBusinessLogicException(thrownException, operationName);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Handle validation exceptions. Must be implemented by subclasses.
+     */
+    public abstract Optional<CompletableFuture<Object>> handleValidationException(ValidationViolationGraphQLException e, String operationName);
+
+    /**
+     * Handle illegal argument exceptions. Must be implemented by subclasses.
+     */
+    public abstract Optional<CompletableFuture<Object>> handleIllegalArgumentException(IllegalArgumentException e, String operationName, ResultPath path);
+
+    protected Optional<CompletableFuture<Object>> handleDataAccessException(DataAccessException e, String operationName) {
+        Object error = schemaErrorMapper.mapDataAccessException(
+                e,
+                operationName,
+                this::createDefaultDataAccessError
+        );
+        return createPayload(operationName, List.of(error));
+    }
+
+    protected Optional<CompletableFuture<Object>> handleBusinessLogicException(Throwable e, String operationName) {
+        return schemaErrorMapper.mapBusinessLogicException(e, operationName)
+                .flatMap(error -> createPayload(operationName, List.of(error)));
+    }
+
+    /**
+     * Create a payload containing the errors for the operation.
+     */
+    protected Optional<CompletableFuture<Object>> createPayload(String operationName, List<?> errors) {
+        return Optional.ofNullable(configuration.getPayloadForField().get(operationName))
+                .map(creator -> creator.createPayload(errors))
+                .map(CompletableFuture::completedFuture);
+    }
+
+    /**
+     * Create a default error for data access exceptions.
+     * Can be overridden by subclasses to customize the default error format.
+     */
+    protected abstract Object createDefaultDataAccessError(String operationName, String message);
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/SchemaErrorMapper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/SchemaErrorMapper.java
@@ -1,0 +1,77 @@
+package no.sikt.graphql.exception;
+
+import org.jooq.exception.DataAccessException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Maps exceptions to schema-based error objects.
+ * <p>
+ * This mapper converts Java exceptions into GraphQL error objects that are defined
+ * in the schema (via @error directives). These errors become part of the data response
+ * in payload fields, not top-level errors.
+ * <p>
+ * Only exceptions that match the configured @error directives are mapped.
+ * Unmatched exceptions are not handled here and will become top-level errors.
+ */
+public class SchemaErrorMapper {
+
+    private final Map<String, List<DataAccessExceptionContentToErrorMapping>> dataAccessMappingsForOperation;
+    private final Map<String, List<GenericExceptionContentToErrorMapping>> genericMappingsForOperation;
+    private final DataAccessExceptionMapper dataAccessExceptionMapper;
+
+    public SchemaErrorMapper(
+            Map<String, List<DataAccessExceptionContentToErrorMapping>> dataAccessMappingsForOperation,
+            Map<String, List<GenericExceptionContentToErrorMapping>> genericMappingsForOperation,
+            DataAccessExceptionMapper dataAccessExceptionMapper) {
+        this.dataAccessMappingsForOperation = dataAccessMappingsForOperation;
+        this.genericMappingsForOperation = genericMappingsForOperation;
+        this.dataAccessExceptionMapper = dataAccessExceptionMapper;
+    }
+
+    /**
+     * Maps a DataAccessException to an error object for the specified operation.
+     * First tries to find a matching configured mapping, otherwise returns a default error.
+     */
+    public Object mapDataAccessException(DataAccessException exception, String operationName, DataAccessDefaultErrorCreator defaultErrorCreator) {
+        return Optional.ofNullable(dataAccessMappingsForOperation.get(operationName))
+                .flatMap(mappings -> findMatchingDataAccessMapping(exception, operationName, mappings))
+                .orElseGet(() -> defaultErrorCreator.createDefaultError(operationName, dataAccessExceptionMapper.getMsgFromException(exception)));
+    }
+
+    /**
+     * Maps a generic business logic exception to an error object for the specified operation.
+     * Returns an Optional containing the mapped error if a matching mapping is found.
+     */
+    public Optional<Object> mapBusinessLogicException(Throwable exception, String operationName) {
+        return Optional.ofNullable(genericMappingsForOperation.get(operationName))
+                .flatMap(mappings -> findMatchingGenericMapping(exception, operationName, mappings));
+    }
+
+    private Optional<Object> findMatchingDataAccessMapping(DataAccessException exception, String operationName,
+                                                           List<DataAccessExceptionContentToErrorMapping> mappings) {
+        return mappings.stream()
+                .filter(mapping -> mapping.matches(exception))
+                .findFirst()
+                .map(mapping -> mapping.handleError(List.of(operationName), exception.getMessage()));
+    }
+
+    private Optional<Object> findMatchingGenericMapping(Throwable exception, String operationName,
+                                                        List<GenericExceptionContentToErrorMapping> mappings) {
+        return mappings.stream()
+                .filter(mapping -> mapping.matches(exception))
+                .findFirst()
+                .map(mapping -> mapping.handleError(List.of(operationName), exception.getMessage()));
+    }
+
+    /**
+     * Functional interface for creating default DataAccess errors.
+     * This is used when no specific mapping is found for a DataAccessException.
+     */
+    @FunctionalInterface
+    public interface DataAccessDefaultErrorCreator {
+        Object createDefaultError(String operationName, String message);
+    }
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/exception/TopLevelErrorHandler.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/exception/TopLevelErrorHandler.java
@@ -1,0 +1,70 @@
+package no.sikt.graphql.exception;
+
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
+import org.jooq.exception.DataAccessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handles exceptions that should become top-level GraphQL errors.
+ * <p>
+ * Top-level errors appear in the standard GraphQL "errors" array at the root of the response.
+ * These are used for technical/exceptional issues like system failures, authentication errors,
+ * or any unhandled exceptions that aren't part of normal business logic flow.
+ * <p>
+ * Exceptions that reach this handler were not handled by SchemaBasedErrorStrategy,
+ * meaning they don't have corresponding @error directives in the schema.
+ */
+public class TopLevelErrorHandler extends SimpleDataFetcherExceptionHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TopLevelErrorHandler.class);
+
+    private final DataAccessExceptionMapper dataAccessExceptionMapper;
+
+    public TopLevelErrorHandler(DataAccessExceptionMapper dataAccessExceptionMapper) {
+        this.dataAccessExceptionMapper = dataAccessExceptionMapper;
+    }
+
+    @Override
+    public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(DataFetcherExceptionHandlerParameters handlerParameters) {
+        Throwable exception = unwrap(handlerParameters.getException());
+        List<GraphQLError> errors;
+
+        if (exception instanceof ValidationViolationGraphQLException) {
+            errors = ((ValidationViolationGraphQLException) exception).getUnderlyingErrors();
+        } else if (exception instanceof IllegalArgumentException) {
+            errors = List.of(GraphqlErrorBuilder.newError(handlerParameters.getDataFetchingEnvironment())
+                    .message(exception.getMessage())
+                    .build());
+        } else if (exception instanceof DataAccessException) {
+            var exceptionID = UUID.randomUUID();
+            LOGGER.error("DataAccessException with id {} caused an unhandled, generic GraphQL-error: ", exceptionID, exception);
+            errors = List.of(
+                    GraphqlErrorBuilder.newError(handlerParameters.getDataFetchingEnvironment())
+                            .message("An exception occurred. The error has been logged with id " + exceptionID + ": " + dataAccessExceptionMapper.getMsgFromException((DataAccessException) exception))
+                            .build()
+            );
+        } else {
+            var exceptionID = UUID.randomUUID();
+            LOGGER.error("Exception with id {} caused an unhandled, generic GraphQL-error: ", exceptionID, exception);
+
+            // Return a generic exception message that does not expose the internal cause
+            errors = List.of(
+                    GraphqlErrorBuilder.newError(handlerParameters.getDataFetchingEnvironment())
+                            .message("An exception occurred. The error has been logged with id " + exceptionID + ".")
+                            .build()
+            );
+        }
+        return CompletableFuture.completedFuture(
+                DataFetcherExceptionHandlerResult.newResult()
+                        .errors(errors)
+                        .build());
+    }
+}

--- a/graphitron-common/src/test/java/no/sikt/graphql/exception/ErrorMessageFormatterTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/exception/ErrorMessageFormatterTest.java
@@ -1,0 +1,149 @@
+package no.sikt.graphql.exception;
+
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorMessageFormatterTest {
+
+    private ErrorMessageFormatter formatter;
+
+    @BeforeEach
+    void setUp() {
+        formatter = new ErrorMessageFormatter();
+    }
+
+    @Test
+    @DisplayName("formats unique constraint violation")
+    void shouldFormatUniqueConstraintViolation() {
+        SQLException sqlException = new SQLException(
+                "ERROR: duplicate key value violates unique constraint \"user_email_key\"",
+                "23505"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Duplicate value not allowed");
+    }
+
+    @Test
+    @DisplayName("formats foreign key constraint violation")
+    void shouldFormatForeignKeyViolation() {
+        SQLException sqlException = new SQLException(
+                "ERROR: violates foreign key constraint",
+                "23503"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Referenced record does not exist");
+    }
+
+    @Test
+    @DisplayName("formats not null constraint violation")
+    void shouldFormatNotNullViolation() {
+        SQLException sqlException = new SQLException(
+                "ERROR: null value in column violates not-null constraint",
+                "23502"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Required field cannot be empty");
+    }
+
+    @Test
+    @DisplayName("formats check constraint violation with constraint name")
+    void shouldFormatCheckConstraintViolation() {
+        SQLException sqlException = new SQLException(
+                "ERROR: new row for relation \"film\" violates check constraint \"year_check\"",
+                "23514"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Value violates constraint: year");
+    }
+
+    @Test
+    @DisplayName("formats check constraint violation without constraint name")
+    void shouldFormatCheckConstraintViolationWithoutName() {
+        SQLException sqlException = new SQLException(
+                "ERROR: violates check constraint",
+                "23514"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Value does not meet validation requirements");
+    }
+
+    @Test
+    @DisplayName("formats data too long error")
+    void shouldFormatDataTooLong() {
+        SQLException sqlException = new SQLException(
+                "ERROR: value too long for type character varying(100)",
+                "22001"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Value exceeds maximum length");
+    }
+
+    @Test
+    @DisplayName("cleans up generic SQL error messages")
+    void shouldCleanupGenericSqlError() {
+        SQLException sqlException = new SQLException(
+                "ERROR:   Something    went   wrong",
+                "99999"
+        );
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Something went wrong");
+    }
+
+    @Test
+    @DisplayName("handles DataAccessException without SQL cause")
+    void shouldHandleExceptionWithoutSqlCause() {
+        DataAccessException exception = new DataAccessException("Connection timeout");
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Connection timeout");
+    }
+
+    @Test
+    @DisplayName("handles SQLException with null message")
+    void shouldHandleSqlExceptionWithNullMessage() {
+        SQLException sqlException = new SQLException(null, "23505");
+        DataAccessException exception = new DataAccessException("Database error", sqlException);
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Database error");
+    }
+
+    @Test
+    @DisplayName("handles exception with blank message")
+    void shouldHandleExceptionWithBlankMessage() {
+        DataAccessException exception = new DataAccessException("   ");
+
+        String result = formatter.formatDataAccessException(exception);
+
+        assertThat(result).isEqualTo("Database operation failed");
+    }
+}

--- a/graphitron-common/src/test/java/no/sikt/graphql/exception/ExceptionStrategyTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/exception/ExceptionStrategyTest.java
@@ -1,0 +1,222 @@
+package no.sikt.graphql.exception;
+
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import org.jooq.exception.DataAccessException;
+import org.jooq.exception.IntegrityConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.BindException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ExceptionStrategyTest {
+
+    private static final String MUTATION1_NAME = "mutation1";
+    private static final String MUTATION_1_PAYLOAD = "mutation1Payload";
+
+    @Mock
+    private DataFetchingEnvironment mockEnvironment;
+    @Mock
+    private GraphQLFieldDefinition mockFieldDefinition;
+
+    private SchemaBasedErrorStrategy underTest;
+
+    private final DataAccessExceptionMapper dataAccessExceptionMapper = new DataAccessExceptionMapper() {
+        @Override
+        public String getMsgFromException(DataAccessException exception) {
+            return "configured exception message";
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        var exceptionToErrorMappingProvider = new TestExceptionToErrorMappingProvider();
+        underTest = new TestSchemaBasedErrorStrategy(
+                new TestMutationExceptionStrategyConfiguration(),
+                exceptionToErrorMappingProvider,
+                dataAccessExceptionMapper
+        );
+        when(mockEnvironment.getFieldDefinition()).thenReturn(mockFieldDefinition);
+        when(mockFieldDefinition.getName()).thenReturn(MUTATION1_NAME);
+    }
+
+    @Test
+    @DisplayName("handleException returns payload when ValidationViolationGraphQLException should be handled")
+    void shouldReturnPayloadWhenValidationViolationGraphQLExceptionShouldBeHandled() throws ExecutionException, InterruptedException {
+        Throwable thrownException = new ValidationViolationGraphQLException(List.of());
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException).orElseThrow().get()).isEqualTo(MUTATION_1_PAYLOAD);
+    }
+
+    @Test
+    @DisplayName("handleException returns payload when IllegalArgumentException should be handled")
+    void shouldReturnPayloadWhenIllegalArgumentExceptionShouldBeHandled() throws ExecutionException, InterruptedException {
+        var executionStepInfo = mock(ExecutionStepInfo.class);
+        when(executionStepInfo.getPath()).thenReturn(mock(ResultPath.class));
+        when(mockEnvironment.getExecutionStepInfo()).thenReturn(executionStepInfo);
+        Throwable thrownException = new IllegalArgumentException();
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException).orElseThrow().get()).isEqualTo(MUTATION_1_PAYLOAD);
+    }
+
+    @Test
+    @DisplayName("handleException returns payload when DataAccessException should be handled")
+    void shouldReturnPayloadWhenDataAccessExceptionShouldBeHandled() throws ExecutionException, InterruptedException {
+        Throwable thrownException = new DataAccessException("error");
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException).orElseThrow().get()).isEqualTo(MUTATION_1_PAYLOAD);
+    }
+
+    @Test
+    @DisplayName("handleException returns payload when exception extending DataAccessException should be handled")
+    void shouldReturnPayloadWhenExtensionOfDataAccessExceptionShouldBeHandled() throws ExecutionException, InterruptedException {
+        Throwable thrownException = new IntegrityConstraintViolationException("error"); //IntegrityConstraintViolationException extends DataAccessException
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException).orElseThrow().get()).isEqualTo(MUTATION_1_PAYLOAD);
+    }
+
+    @Test
+    @DisplayName("handleException returns payload when some generic exception matches")
+    void shouldReturnPayloadWhenSomeGenericExceptionMatches() throws ExecutionException, InterruptedException {
+        Throwable thrownException = new BindException("the exception must contain substring of message to be handled");
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException).orElseThrow().get()).isEqualTo(MUTATION_1_PAYLOAD);
+    }
+
+    @Test
+    @DisplayName("handleException returns empty when the exception message does not match")
+    void shouldReturnEmptyWhenTheExceptionMessageDoesNotMatch() {
+        Throwable thrownException = new BindException("wrong message");
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("handleException returns empty when the exception type does not match")
+    void shouldReturnEmptyWhenTheExceptionTypeDoesNotMatch() {
+        Throwable thrownException = new ArithmeticException("some message");
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("handleException returns empty when the mutation is not configured for the exception type")
+    void shouldReturnEmptyWhenTheMutationIsNotConfiguredForTheExceptionType() {
+        when(mockFieldDefinition.getName()).thenReturn("unconfigured_mutation");
+        Throwable thrownException = new ValidationViolationGraphQLException(List.of());
+
+        assertThat(underTest.handleException(mockEnvironment, thrownException)).isEmpty();
+    }
+
+    private static class TestSchemaBasedErrorStrategy extends SchemaBasedErrorStrategy {
+
+        public TestSchemaBasedErrorStrategy(
+                ExceptionStrategyConfiguration configuration,
+                ExceptionToErrorMappingProvider mappingProvider,
+                DataAccessExceptionMapper dataAccessMapper) {
+            super(configuration, mappingProvider, dataAccessMapper);
+        }
+
+        @Override
+        public Optional<CompletableFuture<Object>> handleValidationException(
+                ValidationViolationGraphQLException e,
+                String operationName) {
+            return Optional.of(CompletableFuture.completedFuture(MUTATION_1_PAYLOAD));
+        }
+
+        @Override
+        public Optional<CompletableFuture<Object>> handleIllegalArgumentException(
+                IllegalArgumentException e,
+                String operationName,
+                ResultPath path) {
+            return Optional.of(CompletableFuture.completedFuture(MUTATION_1_PAYLOAD));
+        }
+
+        @Override
+        protected Object createDefaultDataAccessError(String operationName, String message) {
+            return new SomeError(List.of(operationName), message);
+        }
+
+        @Override
+        protected Optional<CompletableFuture<Object>> createPayload(String operationName, List<?> errors) {
+            // For testing, just return the constant payload
+            return Optional.of(CompletableFuture.completedFuture(MUTATION_1_PAYLOAD));
+        }
+    }
+
+    // Test configuration classes
+    private static class TestMutationExceptionStrategyConfiguration implements ExceptionStrategyConfiguration {
+        @Override
+        public Map<Class<? extends Throwable>, Set<String>> getFieldsForException() {
+            Map<Class<? extends Throwable>, Set<String>> fieldMapping = new HashMap<>();
+            fieldMapping.put(ValidationViolationGraphQLException.class, Set.of(MUTATION1_NAME));
+            fieldMapping.put(IllegalArgumentException.class, Set.of(MUTATION1_NAME));
+            fieldMapping.put(DataAccessException.class, Set.of(MUTATION1_NAME));
+            fieldMapping.put(BindException.class, Set.of(MUTATION1_NAME));
+            return fieldMapping;
+        }
+
+        @Override
+        public Map<String, PayloadCreator> getPayloadForField() {
+            Map<String, PayloadCreator> payloadMapping = new HashMap<>();
+            payloadMapping.put(MUTATION1_NAME, errors -> MUTATION_1_PAYLOAD);
+            return payloadMapping;
+        }
+    }
+
+    private static class TestExceptionToErrorMappingProvider implements ExceptionToErrorMappingProvider {
+        private final Map<String, List<DataAccessExceptionContentToErrorMapping>> dataAccessMappingsForOperation;
+        private final Map<String, List<GenericExceptionContentToErrorMapping>> genericMappingsForOperation;
+
+        public TestExceptionToErrorMappingProvider() {
+            dataAccessMappingsForOperation = new HashMap<>();
+            genericMappingsForOperation = new HashMap<>();
+
+            var m1 = new DataAccessExceptionContentToErrorMapping(
+                    new DataAccessMatcher("20997", null),
+                    (path, msg) -> new SomeError(path, "This is an error"));
+
+            var mutation1DatabaseList = List.of(m1);
+
+            var m2 = new GenericExceptionContentToErrorMapping(
+                    new GenericExceptionMatcher("java.lang.ArithmeticException", null),
+                    (path, msg) -> new SomeError(path, "This is an error"));
+            var m3 = new GenericExceptionContentToErrorMapping(
+                    new GenericExceptionMatcher("java.net.BindException", "substring of message"),
+                    SomeError::new);
+
+            var mutation1GenericList = List.of(m2, m3);
+
+            dataAccessMappingsForOperation.put(MUTATION1_NAME, mutation1DatabaseList);
+            genericMappingsForOperation.put(MUTATION1_NAME, mutation1GenericList);
+        }
+
+        @Override
+        public Map<String, List<DataAccessExceptionContentToErrorMapping>> getDataAccessMappingsForOperation() {
+            return dataAccessMappingsForOperation;
+        }
+
+        @Override
+        public Map<String, List<GenericExceptionContentToErrorMapping>> getGenericMappingsForOperation() {
+            return genericMappingsForOperation;
+        }
+    }
+
+    // Simple error class for testing
+    private record SomeError(List<String> path, String msg) {
+    }
+}

--- a/graphitron-common/src/test/java/no/sikt/graphql/exception/GenericExceptionMatcherTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/exception/GenericExceptionMatcherTest.java
@@ -9,13 +9,14 @@ import java.util.concurrent.CancellationException;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class GenericExceptionMappingContentTest {
 
-    private GenericExceptionMappingContent underTest;
+class GenericExceptionMatcherTest {
+
+    private GenericExceptionMatcher underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new GenericExceptionMappingContent("java.lang.IllegalStateException", "test message");
+        underTest = new GenericExceptionMatcher("java.lang.IllegalStateException", "test message");
     }
 
     @Test

--- a/graphitron-common/src/test/java/no/sikt/graphql/exception/TopLevelErrorHandlerHandlerTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/exception/TopLevelErrorHandlerHandlerTest.java
@@ -1,0 +1,96 @@
+package no.sikt.graphql.exception;
+
+import graphql.GraphqlErrorBuilder;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class TopLevelErrorHandlerHandlerTest {
+
+    @Mock
+    private DataFetcherExceptionHandlerParameters mockHandlerParameters;
+    @Mock
+    private DataFetchingEnvironment mockDataFetchingEnvironment;
+
+    private final DataAccessExceptionMapper dataAccessExceptionMapper = new DataAccessExceptionMapper() {
+        @Override
+        public String getMsgFromException(DataAccessException exception) {
+            return "configured exception message";
+        }
+    };
+
+    @Test
+    public void shouldHandleValidationViolationGraphQLException() {
+        String exceptionMsg = "Validation violation";
+        when(mockHandlerParameters.getException()).thenReturn(new ValidationViolationGraphQLException(List.of(GraphqlErrorBuilder.newError().message(exceptionMsg).build())));
+
+        DataFetcherExceptionHandlerResult result = new TopLevelErrorHandler(dataAccessExceptionMapper).handleException(mockHandlerParameters).join();
+
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getMessage()).isEqualTo(exceptionMsg);
+    }
+
+    @Test
+    public void shouldHandleIllegalArgumentException() {
+        setupDataFetchingEnvironmentMock();
+
+        String exceptionMsg = "Illegal argument";
+        when(mockHandlerParameters.getException()).thenReturn(new IllegalArgumentException(exceptionMsg));
+
+        DataFetcherExceptionHandlerResult result = new TopLevelErrorHandler(dataAccessExceptionMapper).handleException(mockHandlerParameters).join();
+
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getMessage()).isEqualTo(exceptionMsg);
+    }
+
+    @Test
+    public void shouldHandleDataAccessException() {
+        setupDataFetchingEnvironmentMock();
+
+        String exceptionMsg = "Database exception";
+        when(mockHandlerParameters.getException()).thenReturn(new DataAccessException(exceptionMsg));
+
+        DataFetcherExceptionHandlerResult result = new TopLevelErrorHandler(dataAccessExceptionMapper).handleException(mockHandlerParameters).join();
+
+        assertThat(result.getErrors()).hasSize(1);
+        String actualErrorMessage = result.getErrors().get(0).getMessage();
+        assertThat(actualErrorMessage).startsWith("An exception occurred. The error has been logged with id ");
+        assertThat(actualErrorMessage).endsWith(dataAccessExceptionMapper.getMsgFromException(new DataAccessException(exceptionMsg)));
+    }
+
+    @Test
+    public void shouldHandleUnrecognizedException() {
+        setupDataFetchingEnvironmentMock();
+
+        String exceptionMsg = "Implementation details that should not be exposed";
+        when(mockHandlerParameters.getException()).thenReturn(new Exception(exceptionMsg));
+
+        DataFetcherExceptionHandlerResult result = new TopLevelErrorHandler(dataAccessExceptionMapper).handleException(mockHandlerParameters).join();
+
+        assertThat(result.getErrors()).hasSize(1);
+        String actualErrorMessage = result.getErrors().get(0).getMessage();
+        assertThat(actualErrorMessage).startsWith("An exception occurred. The error has been logged with id ");
+        assertThat(actualErrorMessage).doesNotContain(exceptionMsg);
+    }
+
+    private void setupDataFetchingEnvironmentMock() {
+        when(mockDataFetchingEnvironment.getField()).thenReturn(mock(Field.class));
+        when(mockDataFetchingEnvironment.getExecutionStepInfo()).thenReturn(mock(ExecutionStepInfo.class));
+        when(mockHandlerParameters.getDataFetchingEnvironment()).thenReturn(mockDataFetchingEnvironment);
+    }
+}

--- a/graphitron-example/graphitron-example-db/pom.xml
+++ b/graphitron-example/graphitron-example-db/pom.xml
@@ -27,9 +27,8 @@
             <artifactId>jooq</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>8.0.2.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -71,6 +70,9 @@
                                             <packageName>${generatedJooqPackage}</packageName>
                                             <directory>src/main/java</directory>
                                         </target>
+                                        <generate>
+                                            <validationAnnotations>true</validationAnnotations>
+                                        </generate>
                                     </generator>
                                 </configuration>
                             </execution>

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/ActorInfoRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/ActorInfoRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import no.sikt.graphitron.example.generated.jooq.tables.ActorInfo;
 
 import org.jooq.impl.TableRecordImpl;
@@ -41,6 +43,7 @@ public class ActorInfoRecord extends TableRecordImpl<ActorInfoRecord> {
     /**
      * Getter for <code>public.actor_info.first_name</code>.
      */
+    @Size(max = 45)
     public String getFirstName() {
         return (String) get(1);
     }
@@ -55,6 +58,7 @@ public class ActorInfoRecord extends TableRecordImpl<ActorInfoRecord> {
     /**
      * Getter for <code>public.actor_info.last_name</code>.
      */
+    @Size(max = 45)
     public String getLastName() {
         return (String) get(2);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/ActorRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/ActorRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Actor;
@@ -44,6 +47,8 @@ public class ActorRecord extends UpdatableRecordImpl<ActorRecord> {
     /**
      * Getter for <code>public.actor.first_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getFirstName() {
         return (String) get(1);
     }
@@ -58,6 +63,8 @@ public class ActorRecord extends UpdatableRecordImpl<ActorRecord> {
     /**
      * Getter for <code>public.actor.last_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getLastName() {
         return (String) get(2);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/AddressRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/AddressRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Address;
@@ -44,6 +47,8 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.address</code>.
      */
+    @NotNull
+    @Size(max = 50)
     public String getAddress() {
         return (String) get(1);
     }
@@ -58,6 +63,7 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.address2</code>.
      */
+    @Size(max = 50)
     public String getAddress2() {
         return (String) get(2);
     }
@@ -72,6 +78,8 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.district</code>.
      */
+    @NotNull
+    @Size(max = 20)
     public String getDistrict() {
         return (String) get(3);
     }
@@ -86,6 +94,7 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.city_id</code>.
      */
+    @NotNull
     public Integer getCityId() {
         return (Integer) get(4);
     }
@@ -100,6 +109,7 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.postal_code</code>.
      */
+    @Size(max = 10)
     public String getPostalCode() {
         return (String) get(5);
     }
@@ -114,6 +124,8 @@ public class AddressRecord extends UpdatableRecordImpl<AddressRecord> {
     /**
      * Getter for <code>public.address.phone</code>.
      */
+    @NotNull
+    @Size(max = 20)
     public String getPhone() {
         return (String) get(6);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CategoryRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CategoryRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Category;
@@ -44,6 +47,8 @@ public class CategoryRecord extends UpdatableRecordImpl<CategoryRecord> {
     /**
      * Getter for <code>public.category.name</code>.
      */
+    @NotNull
+    @Size(max = 25)
     public String getName() {
         return (String) get(1);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CityRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CityRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.City;
@@ -44,6 +47,8 @@ public class CityRecord extends UpdatableRecordImpl<CityRecord> {
     /**
      * Getter for <code>public.city.city</code>.
      */
+    @NotNull
+    @Size(max = 50)
     public String getCity() {
         return (String) get(1);
     }
@@ -58,6 +63,7 @@ public class CityRecord extends UpdatableRecordImpl<CityRecord> {
     /**
      * Getter for <code>public.city.country_id</code>.
      */
+    @NotNull
     public Integer getCountryId() {
         return (Integer) get(2);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CountryRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CountryRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Country;
@@ -44,6 +47,8 @@ public class CountryRecord extends UpdatableRecordImpl<CountryRecord> {
     /**
      * Getter for <code>public.country.country</code>.
      */
+    @NotNull
+    @Size(max = 50)
     public String getCountry() {
         return (String) get(1);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CustomerListRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CustomerListRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import no.sikt.graphitron.example.generated.jooq.tables.CustomerList;
 
 import org.jooq.impl.TableRecordImpl;
@@ -55,6 +57,7 @@ public class CustomerListRecord extends TableRecordImpl<CustomerListRecord> {
     /**
      * Getter for <code>public.customer_list.address</code>.
      */
+    @Size(max = 50)
     public String getAddress() {
         return (String) get(2);
     }
@@ -69,6 +72,7 @@ public class CustomerListRecord extends TableRecordImpl<CustomerListRecord> {
     /**
      * Getter for <code>public.customer_list.zip code</code>.
      */
+    @Size(max = 10)
     public String getZipCode() {
         return (String) get(3);
     }
@@ -83,6 +87,7 @@ public class CustomerListRecord extends TableRecordImpl<CustomerListRecord> {
     /**
      * Getter for <code>public.customer_list.phone</code>.
      */
+    @Size(max = 20)
     public String getPhone() {
         return (String) get(4);
     }
@@ -97,6 +102,7 @@ public class CustomerListRecord extends TableRecordImpl<CustomerListRecord> {
     /**
      * Getter for <code>public.customer_list.city</code>.
      */
+    @Size(max = 50)
     public String getCity() {
         return (String) get(5);
     }
@@ -111,6 +117,7 @@ public class CustomerListRecord extends TableRecordImpl<CustomerListRecord> {
     /**
      * Getter for <code>public.customer_list.country</code>.
      */
+    @Size(max = 50)
     public String getCountry() {
         return (String) get(6);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CustomerRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/CustomerRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -45,6 +48,7 @@ public class CustomerRecord extends UpdatableRecordImpl<CustomerRecord> {
     /**
      * Getter for <code>public.customer.store_id</code>.
      */
+    @NotNull
     public Integer getStoreId() {
         return (Integer) get(1);
     }
@@ -59,6 +63,8 @@ public class CustomerRecord extends UpdatableRecordImpl<CustomerRecord> {
     /**
      * Getter for <code>public.customer.first_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getFirstName() {
         return (String) get(2);
     }
@@ -73,6 +79,8 @@ public class CustomerRecord extends UpdatableRecordImpl<CustomerRecord> {
     /**
      * Getter for <code>public.customer.last_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getLastName() {
         return (String) get(3);
     }
@@ -87,6 +95,7 @@ public class CustomerRecord extends UpdatableRecordImpl<CustomerRecord> {
     /**
      * Getter for <code>public.customer.email</code>.
      */
+    @Size(max = 50)
     public String getEmail() {
         return (String) get(4);
     }
@@ -101,6 +110,7 @@ public class CustomerRecord extends UpdatableRecordImpl<CustomerRecord> {
     /**
      * Getter for <code>public.customer.address_id</code>.
      */
+    @NotNull
     public Integer getAddressId() {
         return (Integer) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmActorRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmActorRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.FilmActor;
@@ -30,6 +32,7 @@ public class FilmActorRecord extends UpdatableRecordImpl<FilmActorRecord> {
     /**
      * Getter for <code>public.film_actor.actor_id</code>.
      */
+    @NotNull
     public Integer getActorId() {
         return (Integer) get(0);
     }
@@ -44,6 +47,7 @@ public class FilmActorRecord extends UpdatableRecordImpl<FilmActorRecord> {
     /**
      * Getter for <code>public.film_actor.film_id</code>.
      */
+    @NotNull
     public Integer getFilmId() {
         return (Integer) get(1);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmCategoryRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmCategoryRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.FilmCategory;
@@ -30,6 +32,7 @@ public class FilmCategoryRecord extends UpdatableRecordImpl<FilmCategoryRecord> 
     /**
      * Getter for <code>public.film_category.film_id</code>.
      */
+    @NotNull
     public Integer getFilmId() {
         return (Integer) get(0);
     }
@@ -44,6 +47,7 @@ public class FilmCategoryRecord extends UpdatableRecordImpl<FilmCategoryRecord> 
     /**
      * Getter for <code>public.film_category.category_id</code>.
      */
+    @NotNull
     public Integer getCategoryId() {
         return (Integer) get(1);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmListRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmListRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import java.math.BigDecimal;
 
 import no.sikt.graphitron.example.generated.jooq.enums.MpaaRating;
@@ -44,6 +46,7 @@ public class FilmListRecord extends TableRecordImpl<FilmListRecord> {
     /**
      * Getter for <code>public.film_list.title</code>.
      */
+    @Size(max = 255)
     public String getTitle() {
         return (String) get(1);
     }
@@ -72,6 +75,7 @@ public class FilmListRecord extends TableRecordImpl<FilmListRecord> {
     /**
      * Getter for <code>public.film_list.category</code>.
      */
+    @Size(max = 25)
     public String getCategory() {
         return (String) get(3);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/FilmRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -46,6 +49,8 @@ public class FilmRecord extends UpdatableRecordImpl<FilmRecord> {
     /**
      * Getter for <code>public.film.title</code>.
      */
+    @NotNull
+    @Size(max = 255)
     public String getTitle() {
         return (String) get(1);
     }
@@ -88,6 +93,7 @@ public class FilmRecord extends UpdatableRecordImpl<FilmRecord> {
     /**
      * Getter for <code>public.film.language_id</code>.
      */
+    @NotNull
     public Integer getLanguageId() {
         return (Integer) get(4);
     }
@@ -226,6 +232,7 @@ public class FilmRecord extends UpdatableRecordImpl<FilmRecord> {
      * configuration.
      */
     @Deprecated
+    @NotNull
     public Object getFulltext() {
         return get(13);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/InventoryRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/InventoryRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Inventory;
@@ -44,6 +46,7 @@ public class InventoryRecord extends UpdatableRecordImpl<InventoryRecord> {
     /**
      * Getter for <code>public.inventory.film_id</code>.
      */
+    @NotNull
     public Integer getFilmId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class InventoryRecord extends UpdatableRecordImpl<InventoryRecord> {
     /**
      * Getter for <code>public.inventory.store_id</code>.
      */
+    @NotNull
     public Integer getStoreId() {
         return (Integer) get(2);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/LanguageRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/LanguageRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Language;
@@ -44,6 +47,8 @@ public class LanguageRecord extends UpdatableRecordImpl<LanguageRecord> {
     /**
      * Getter for <code>public.language.name</code>.
      */
+    @NotNull
+    @Size(max = 20)
     public String getName() {
         return (String) get(1);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/NicerButSlowerFilmListRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/NicerButSlowerFilmListRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import java.math.BigDecimal;
 
 import no.sikt.graphitron.example.generated.jooq.enums.MpaaRating;
@@ -44,6 +46,7 @@ public class NicerButSlowerFilmListRecord extends TableRecordImpl<NicerButSlower
     /**
      * Getter for <code>public.nicer_but_slower_film_list.title</code>.
      */
+    @Size(max = 255)
     public String getTitle() {
         return (String) get(1);
     }
@@ -72,6 +75,7 @@ public class NicerButSlowerFilmListRecord extends TableRecordImpl<NicerButSlower
     /**
      * Getter for <code>public.nicer_but_slower_film_list.category</code>.
      */
+    @Size(max = 25)
     public String getCategory() {
         return (String) get(3);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_01Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_01Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_01Record extends TableRecordImpl<PaymentP2007_01Record
     /**
      * Getter for <code>public.payment_p2007_01.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_01Record extends TableRecordImpl<PaymentP2007_01Record
     /**
      * Getter for <code>public.payment_p2007_01.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_01Record extends TableRecordImpl<PaymentP2007_01Record
     /**
      * Getter for <code>public.payment_p2007_01.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_01Record extends TableRecordImpl<PaymentP2007_01Record
     /**
      * Getter for <code>public.payment_p2007_01.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_01Record extends TableRecordImpl<PaymentP2007_01Record
     /**
      * Getter for <code>public.payment_p2007_01.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_02Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_02Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_02Record extends TableRecordImpl<PaymentP2007_02Record
     /**
      * Getter for <code>public.payment_p2007_02.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_02Record extends TableRecordImpl<PaymentP2007_02Record
     /**
      * Getter for <code>public.payment_p2007_02.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_02Record extends TableRecordImpl<PaymentP2007_02Record
     /**
      * Getter for <code>public.payment_p2007_02.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_02Record extends TableRecordImpl<PaymentP2007_02Record
     /**
      * Getter for <code>public.payment_p2007_02.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_02Record extends TableRecordImpl<PaymentP2007_02Record
     /**
      * Getter for <code>public.payment_p2007_02.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_03Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_03Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_03Record extends TableRecordImpl<PaymentP2007_03Record
     /**
      * Getter for <code>public.payment_p2007_03.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_03Record extends TableRecordImpl<PaymentP2007_03Record
     /**
      * Getter for <code>public.payment_p2007_03.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_03Record extends TableRecordImpl<PaymentP2007_03Record
     /**
      * Getter for <code>public.payment_p2007_03.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_03Record extends TableRecordImpl<PaymentP2007_03Record
     /**
      * Getter for <code>public.payment_p2007_03.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_03Record extends TableRecordImpl<PaymentP2007_03Record
     /**
      * Getter for <code>public.payment_p2007_03.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_04Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_04Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_04Record extends TableRecordImpl<PaymentP2007_04Record
     /**
      * Getter for <code>public.payment_p2007_04.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_04Record extends TableRecordImpl<PaymentP2007_04Record
     /**
      * Getter for <code>public.payment_p2007_04.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_04Record extends TableRecordImpl<PaymentP2007_04Record
     /**
      * Getter for <code>public.payment_p2007_04.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_04Record extends TableRecordImpl<PaymentP2007_04Record
     /**
      * Getter for <code>public.payment_p2007_04.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_04Record extends TableRecordImpl<PaymentP2007_04Record
     /**
      * Getter for <code>public.payment_p2007_04.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_05Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_05Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_05Record extends TableRecordImpl<PaymentP2007_05Record
     /**
      * Getter for <code>public.payment_p2007_05.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_05Record extends TableRecordImpl<PaymentP2007_05Record
     /**
      * Getter for <code>public.payment_p2007_05.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_05Record extends TableRecordImpl<PaymentP2007_05Record
     /**
      * Getter for <code>public.payment_p2007_05.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_05Record extends TableRecordImpl<PaymentP2007_05Record
     /**
      * Getter for <code>public.payment_p2007_05.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_05Record extends TableRecordImpl<PaymentP2007_05Record
     /**
      * Getter for <code>public.payment_p2007_05.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_06Record.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentP2007_06Record.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -44,6 +46,7 @@ public class PaymentP2007_06Record extends TableRecordImpl<PaymentP2007_06Record
     /**
      * Getter for <code>public.payment_p2007_06.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class PaymentP2007_06Record extends TableRecordImpl<PaymentP2007_06Record
     /**
      * Getter for <code>public.payment_p2007_06.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class PaymentP2007_06Record extends TableRecordImpl<PaymentP2007_06Record
     /**
      * Getter for <code>public.payment_p2007_06.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -86,6 +91,7 @@ public class PaymentP2007_06Record extends TableRecordImpl<PaymentP2007_06Record
     /**
      * Getter for <code>public.payment_p2007_06.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -100,6 +106,7 @@ public class PaymentP2007_06Record extends TableRecordImpl<PaymentP2007_06Record
     /**
      * Getter for <code>public.payment_p2007_06.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/PaymentRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -45,6 +47,7 @@ public class PaymentRecord extends UpdatableRecordImpl<PaymentRecord> {
     /**
      * Getter for <code>public.payment.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(1);
     }
@@ -59,6 +62,7 @@ public class PaymentRecord extends UpdatableRecordImpl<PaymentRecord> {
     /**
      * Getter for <code>public.payment.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(2);
     }
@@ -73,6 +77,7 @@ public class PaymentRecord extends UpdatableRecordImpl<PaymentRecord> {
     /**
      * Getter for <code>public.payment.rental_id</code>.
      */
+    @NotNull
     public Integer getRentalId() {
         return (Integer) get(3);
     }
@@ -87,6 +92,7 @@ public class PaymentRecord extends UpdatableRecordImpl<PaymentRecord> {
     /**
      * Getter for <code>public.payment.amount</code>.
      */
+    @NotNull
     public BigDecimal getAmount() {
         return (BigDecimal) get(4);
     }
@@ -101,6 +107,7 @@ public class PaymentRecord extends UpdatableRecordImpl<PaymentRecord> {
     /**
      * Getter for <code>public.payment.payment_date</code>.
      */
+    @NotNull
     public LocalDateTime getPaymentDate() {
         return (LocalDateTime) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/RentalRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/RentalRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Rental;
@@ -44,6 +46,7 @@ public class RentalRecord extends UpdatableRecordImpl<RentalRecord> {
     /**
      * Getter for <code>public.rental.rental_date</code>.
      */
+    @NotNull
     public LocalDateTime getRentalDate() {
         return (LocalDateTime) get(1);
     }
@@ -58,6 +61,7 @@ public class RentalRecord extends UpdatableRecordImpl<RentalRecord> {
     /**
      * Getter for <code>public.rental.inventory_id</code>.
      */
+    @NotNull
     public Integer getInventoryId() {
         return (Integer) get(2);
     }
@@ -72,6 +76,7 @@ public class RentalRecord extends UpdatableRecordImpl<RentalRecord> {
     /**
      * Getter for <code>public.rental.customer_id</code>.
      */
+    @NotNull
     public Integer getCustomerId() {
         return (Integer) get(3);
     }
@@ -100,6 +105,7 @@ public class RentalRecord extends UpdatableRecordImpl<RentalRecord> {
     /**
      * Getter for <code>public.rental.staff_id</code>.
      */
+    @NotNull
     public Integer getStaffId() {
         return (Integer) get(5);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/SalesByFilmCategoryRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/SalesByFilmCategoryRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import java.math.BigDecimal;
 
 import no.sikt.graphitron.example.generated.jooq.tables.SalesByFilmCategory;
@@ -29,6 +31,7 @@ public class SalesByFilmCategoryRecord extends TableRecordImpl<SalesByFilmCatego
     /**
      * Getter for <code>public.sales_by_film_category.category</code>.
      */
+    @Size(max = 25)
     public String getCategory() {
         return (String) get(0);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StaffListRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StaffListRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.Size;
+
 import no.sikt.graphitron.example.generated.jooq.tables.StaffList;
 
 import org.jooq.impl.TableRecordImpl;
@@ -55,6 +57,7 @@ public class StaffListRecord extends TableRecordImpl<StaffListRecord> {
     /**
      * Getter for <code>public.staff_list.address</code>.
      */
+    @Size(max = 50)
     public String getAddress() {
         return (String) get(2);
     }
@@ -69,6 +72,7 @@ public class StaffListRecord extends TableRecordImpl<StaffListRecord> {
     /**
      * Getter for <code>public.staff_list.zip code</code>.
      */
+    @Size(max = 10)
     public String getZipCode() {
         return (String) get(3);
     }
@@ -83,6 +87,7 @@ public class StaffListRecord extends TableRecordImpl<StaffListRecord> {
     /**
      * Getter for <code>public.staff_list.phone</code>.
      */
+    @Size(max = 20)
     public String getPhone() {
         return (String) get(4);
     }
@@ -97,6 +102,7 @@ public class StaffListRecord extends TableRecordImpl<StaffListRecord> {
     /**
      * Getter for <code>public.staff_list.city</code>.
      */
+    @Size(max = 50)
     public String getCity() {
         return (String) get(5);
     }
@@ -111,6 +117,7 @@ public class StaffListRecord extends TableRecordImpl<StaffListRecord> {
     /**
      * Getter for <code>public.staff_list.country</code>.
      */
+    @Size(max = 50)
     public String getCountry() {
         return (String) get(6);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StaffRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StaffRecord.java
@@ -4,6 +4,9 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Staff;
@@ -44,6 +47,8 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.first_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getFirstName() {
         return (String) get(1);
     }
@@ -58,6 +63,8 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.last_name</code>.
      */
+    @NotNull
+    @Size(max = 45)
     public String getLastName() {
         return (String) get(2);
     }
@@ -72,6 +79,7 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.address_id</code>.
      */
+    @NotNull
     public Integer getAddressId() {
         return (Integer) get(3);
     }
@@ -86,6 +94,7 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.email</code>.
      */
+    @Size(max = 50)
     public String getEmail() {
         return (String) get(4);
     }
@@ -100,6 +109,7 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.store_id</code>.
      */
+    @NotNull
     public Integer getStoreId() {
         return (Integer) get(5);
     }
@@ -128,6 +138,8 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.username</code>.
      */
+    @NotNull
+    @Size(max = 16)
     public String getUsername() {
         return (String) get(7);
     }
@@ -142,6 +154,7 @@ public class StaffRecord extends UpdatableRecordImpl<StaffRecord> {
     /**
      * Getter for <code>public.staff.password</code>.
      */
+    @Size(max = 40)
     public String getPassword() {
         return (String) get(8);
     }

--- a/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StoreRecord.java
+++ b/graphitron-example/graphitron-example-db/src/main/java/no/sikt/graphitron/example/generated/jooq/tables/records/StoreRecord.java
@@ -4,6 +4,8 @@
 package no.sikt.graphitron.example.generated.jooq.tables.records;
 
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Store;
@@ -44,6 +46,7 @@ public class StoreRecord extends UpdatableRecordImpl<StoreRecord> {
     /**
      * Getter for <code>public.store.manager_staff_id</code>.
      */
+    @NotNull
     public Integer getManagerStaffId() {
         return (Integer) get(1);
     }
@@ -58,6 +61,7 @@ public class StoreRecord extends UpdatableRecordImpl<StoreRecord> {
     /**
      * Getter for <code>public.store.address_id</code>.
      */
+    @NotNull
     public Integer getAddressId() {
         return (Integer) get(2);
     }

--- a/graphitron-example/graphitron-example-server/pom.xml
+++ b/graphitron-example/graphitron-example-server/pom.xml
@@ -73,6 +73,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/exceptionhandling/SchemaBasedErrorStrategyImpl.java
+++ b/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/exceptionhandling/SchemaBasedErrorStrategyImpl.java
@@ -1,0 +1,60 @@
+package no.sikt.graphitron.example.exceptionhandling;
+
+import graphql.execution.ResultPath;
+import no.sikt.graphitron.example.generated.graphitron.model.InvalidInput;
+import no.sikt.graphql.exception.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of schema-based error strategy for GraphQL operations.
+ * Handles validation and illegal argument exceptions by mapping them to InvalidInput errors
+ * that appear in the payload's errors field (not as top-level errors).
+ */
+public class SchemaBasedErrorStrategyImpl extends SchemaBasedErrorStrategy {
+
+    public SchemaBasedErrorStrategyImpl(
+            ExceptionStrategyConfiguration configuration, 
+            ExceptionToErrorMappingProvider mappingProvider, 
+            DataAccessExceptionMapper dataAccessMapper) {
+        super(configuration, mappingProvider, dataAccessMapper);
+    }
+
+    @Override
+    public Optional<CompletableFuture<Object>> handleValidationException(ValidationViolationGraphQLException e, String operationName) {
+        List<InvalidInput> errors =
+                e.getUnderlyingErrors()
+                        .stream()
+                        .map(it -> new InvalidInput(
+                                it.getPath()
+                                        .stream()
+                                        .map(Object::toString)
+                                        .collect(Collectors.toList()),
+                                it.getMessage()))
+                        .collect(Collectors.toList());
+
+        return createPayload(operationName, errors);
+    }
+
+    @Override
+    public Optional<CompletableFuture<Object>> handleIllegalArgumentException(IllegalArgumentException e, String operationName, ResultPath path) {
+        return createPayload(operationName, List.of(
+                new InvalidInput(
+                        path.toList().stream().map(Object::toString).collect(Collectors.toList()),
+                        e.getMessage())
+                )
+        );
+    }
+    
+    @Override
+    protected Object createDefaultDataAccessError(String operationName, String message) {
+        // Create a default InvalidInput error for data access exceptions
+        return new InvalidInput(
+                List.of(operationName),
+                message
+        );
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/server/SubNodeIdStrategy.java
+++ b/graphitron-example/graphitron-example-server/src/main/java/no/sikt/graphitron/example/server/SubNodeIdStrategy.java
@@ -2,10 +2,6 @@ package no.sikt.graphitron.example.server;
 
 import jakarta.inject.Singleton;
 import no.sikt.graphql.NodeIdStrategy;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
-import org.jooq.Field;
-import org.jooq.SelectField;
 
 @Singleton
 public class SubNodeIdStrategy extends NodeIdStrategy {

--- a/graphitron-example/graphitron-example-server/src/main/resources/META-INF/jooq-validation-mapping.xml
+++ b/graphitron-example/graphitron-example-server/src/main/resources/META-INF/jooq-validation-mapping.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<constraint-mappings
+    xmlns="http://jboss.org/xml/ns/javax/validation/mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/mapping
+        validation-mapping-1.1.xsd"
+    version="1.1">
+    
+    <bean class="no.sikt.graphitron.example.generated.jooq.tables.records.FilmRecord" ignore-annotations="false"/>
+</constraint-mappings>

--- a/graphitron-example/graphitron-example-server/src/main/resources/META-INF/validation.xml
+++ b/graphitron-example/graphitron-example-server/src/main/resources/META-INF/validation.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validation-config
+    xmlns="http://jboss.org/xml/ns/javax/validation/configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/configuration
+        validation-configuration-1.1.xsd"
+    version="1.1">
+    
+    <constraint-mapping>META-INF/jooq-validation-mapping.xml</constraint-mapping>
+</validation-config>

--- a/graphitron-example/graphitron-example-server/src/test/java/no/sikt/graphitron/example/server/approval/ApprovalQueryTest.java
+++ b/graphitron-example/graphitron-example-server/src/test/java/no/sikt/graphitron/example/server/approval/ApprovalQueryTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,6 +45,8 @@ public class ApprovalQueryTest {
     private static final Path QUERY_FILE_DIRECTORY = Paths.get("src", "test", "resources", "approval", "queries");
     private static final Path APPROVALS_FILE_DIRECTORY = Paths.get("src", "test", "resources", "approval", "approvals");
 
+    private static final Pattern UUID_PATTERN = Pattern.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}");
+
     @DisplayName("Verifying recorded query results")
     @ParameterizedTest(name = "{index} {0} - {4} - variables ({3})")
     @MethodSource("queryFiles")
@@ -59,6 +62,7 @@ public class ApprovalQueryTest {
                 .asPrettyString();
 
         verify(response, new Options()
+                .withScrubber(str -> UUID_PATTERN.matcher(str).replaceAll("[UUID]"))
                 .forFile().withNamer(new NamerWrapper(
                         () -> queryFile.replace(".graphql", "-" + variableIdx + ".result"),
                         APPROVALS_FILE_DIRECTORY::toString))

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_databaseEx_handled-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_databaseEx_handled-1.result.approved.json
@@ -1,0 +1,16 @@
+{
+    "data": {
+        "updateFilmReleaseYear_handledError": {
+            "errors": [
+                {
+                    "__typename": "InvalidInput",
+                    "message": "Release year must be between 1901 and 2155",
+                    "path": [
+                        "updateFilmReleaseYear_handledError"
+                    ]
+                }
+            ],
+            "film": null
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_databaseEx_topLevel-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_databaseEx_topLevel-1.result.approved.json
@@ -1,0 +1,22 @@
+{
+    "errors": [
+        {
+            "message": "An exception occurred. The error has been logged with id [UUID]: Value violates constraint: year",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "updateFilmReleaseYear_topLevelError"
+            ],
+            "extensions": {
+                "classification": "DataFetchingException"
+            }
+        }
+    ],
+    "data": {
+        "updateFilmReleaseYear_topLevelError": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_jakarta_bean_validation-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_mutation_jakarta_bean_validation-1.result.approved.json
@@ -1,0 +1,25 @@
+{
+    "errors": [
+        {
+            "message": "size must be between 0 and 255",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "updateFilmName",
+                "in",
+                "0",
+                "title"
+            ],
+            "extensions": {
+                "classification": "ValidationError"
+            }
+        }
+    ],
+    "data": {
+        "updateFilmName": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_businessLogicEx_handled-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_businessLogicEx_handled-1.result.approved.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "allCustomerEmails_handledError": {
+            "errors": [
+                {
+                    "__typename": "CustomerEmailsError",
+                    "path": [
+                        "allCustomerEmails_handledError"
+                    ],
+                    "message": "You do not have access to customer emails"
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_businessLogicEx_topLevel-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_businessLogicEx_topLevel-1.result.approved.json
@@ -1,0 +1,22 @@
+{
+    "errors": [
+        {
+            "message": "An exception occurred. The error has been logged with id [UUID].",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "allCustomerEmails_topLevelError"
+            ],
+            "extensions": {
+                "classification": "DataFetchingException"
+            }
+        }
+    ],
+    "data": {
+        "allCustomerEmails_topLevelError": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_illegalArgumentEx_topLevel-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_illegalArgumentEx_topLevel-1.result.approved.json
@@ -1,0 +1,22 @@
+{
+    "errors": [
+        {
+            "message": "This is the error message from the IllegalArgumentException",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "allCustomerEmails_iea_topLevelError"
+            ],
+            "extensions": {
+                "classification": "DataFetchingException"
+            }
+        }
+    ],
+    "data": {
+        "allCustomerEmails_iea_topLevelError": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_databaseEx_handled.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_databaseEx_handled.graphql
@@ -1,0 +1,14 @@
+mutation {
+  updateFilmReleaseYear_handledError(in: {filmId: "RmlsbTox", releaseYear: 2999}) {
+    errors {
+      ... on InvalidInput {
+        __typename
+        message
+        path
+      }
+    }
+    film {
+      id
+    }
+  }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_databaseEx_topLevel.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_databaseEx_topLevel.graphql
@@ -1,0 +1,5 @@
+mutation {
+    updateFilmReleaseYear_topLevelError(in: {filmId: "RmlsbTox", releaseYear: 2999}) {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_jakarta_bean_validation.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_mutation_jakarta_bean_validation.graphql
@@ -1,0 +1,8 @@
+mutation {
+    updateFilmName(in: {
+        filmId: "RmlsbToxNQ",
+        title: "This is an extremely long film title that exceeds the maximum allowed length of 255 characters. It contains way too many words and will definitely trigger a validation error when we try to update the film record with this excessively long title that just keeps going on and on without any real purpose other than to test the validation"
+    }) {
+        title
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_businessLogicEx_handled.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_businessLogicEx_handled.graphql
@@ -1,0 +1,9 @@
+query {
+    allCustomerEmails_handledError {
+        errors {
+            __typename
+            path
+            message
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_businessLogicEx_topLevel.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_businessLogicEx_topLevel.graphql
@@ -1,0 +1,5 @@
+query {
+    allCustomerEmails_topLevelError {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_illegalArgumentEx_topLevel.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_illegalArgumentEx_topLevel.graphql
@@ -1,0 +1,5 @@
+query {
+    allCustomerEmails_iea_topLevelError {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
@@ -45,6 +45,13 @@ public class CustomerService {
         );
     }
 
+    public List<CustomerRecord> allCustomerEmails() {
+        throw new IllegalStateException("You are not allowed to access emails");
+    }
+
+    public List<CustomerRecord> allCustomerEmails_IllegalArgument() {
+        throw new IllegalArgumentException("This is the error message from the IllegalArgumentException");
+    }
 
     public List<UpdateCustomerEmailResult> updateCustomerEmail(List<UpdateCustomerEmailRecord> input) {
         var customer = new CustomerRecord();

--- a/graphitron-example/graphitron-example-spec/pom.xml
+++ b/graphitron-example/graphitron-example-spec/pom.xml
@@ -37,9 +37,9 @@
             <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>8.0.2.Final</version>
+            <groupId>no.sikt</groupId>
+            <artifactId>graphitron-error-handling-jakarta</artifactId>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
@@ -115,8 +115,8 @@
                             <jooqGeneratedPackage>${generatedJooqPackage}</jooqGeneratedPackage>
                             <maxAllowedPageSize>1000</maxAllowedPageSize>
                             <recordValidation>
-                                <enabled>false</enabled>
-                                <schemaErrorType>UgyldigInput</schemaErrorType>
+                                <enabled>true</enabled>
+                                <schemaErrorType>InvalidInput</schemaErrorType>
                             </recordValidation>
                             <outputPackage>${generatedGraphitronPackage}</outputPackage>
                             <externalReferenceImports>

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/errorHandling.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/errorHandling.graphql
@@ -1,0 +1,64 @@
+extend type Mutation {
+    #Tests database level exception handling. Errors defined in payload
+    updateFilmReleaseYear_handledError(in: FilmReleaseYearInput!): FilmPayload @mutation(typeName: UPDATE)
+    #Tests database level exception handling. Errors not in payload. Errors are thus returned 'top level'
+    updateFilmReleaseYear_topLevelError(in: FilmReleaseYearInput!): [Film!] @mutation(typeName: UPDATE)
+}
+
+extend type Query {
+    #Tests business logic exception handling. Errors in payload
+    allCustomerEmails_handledError: CustomerEmailsPayload @service(
+        service: {
+            className: "no.sikt.graphitron.example.service.CustomerService",
+            method: "allCustomerEmails"
+        }
+    )
+    #Tests business logic exception handling. Errors not in payload. Errors are thus returned 'top level'
+    allCustomerEmails_topLevelError: [Customer!] @service(
+        service: {
+            className: "no.sikt.graphitron.example.service.CustomerService",
+            method: "allCustomerEmails"
+        }
+    )
+    #Tests illegal argument exception handling. Errors not in payload. Errors are thus returned 'top level'
+    allCustomerEmails_iea_topLevelError: [Customer!] @service(
+        service: {
+            className: "no.sikt.graphitron.example.service.CustomerService",
+            method: "allCustomerEmails_illegalArgument"
+        }
+    )
+}
+
+type CustomerEmailsPayload{
+    customers: [Customer!]
+    errors:  [CustomerEmailsError!]
+}
+
+type CustomerEmailsError implements Error @error(handlers: [
+    {handler: GENERIC, matches: "not allowed", className: "java.lang.IllegalStateException" description: "You do not have access to customer emails"}]) {
+    path: [String!]!
+    message: String!
+}
+
+input FilmReleaseYearInput @table(name: "FILM") {
+    filmId: ID! @nodeId(typeName: "Film")
+    releaseYear: Int @field(name: "RELEASE_YEAR") # constrained (((VALUE >= 1901) AND (VALUE <= 2155))
+}
+
+type FilmPayload {
+    film: [Film!]
+    errors: [UpdateFilmNameError!]
+}
+
+union UpdateFilmNameError = InvalidInput
+
+interface Error {
+    path: [String!]!
+    message: String!
+}
+
+type InvalidInput implements Error @error(handlers: [
+    {handler: DATABASE, code: "0", matches: "year_check", description: "Release year must be between 1901 and 2155"}]) {
+    path: [String!]!
+    message: String!
+}

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.20.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
                 <version>3.9.11</version>


### PR DESCRIPTION
  Migrates exception handling framework from downstream projects  into Graphitron common, including unit tests.

  **Key changes:**
  - Refactored to clearly distinguish between top-level errors (GraphQL errors array) and schema-based errors (payload error fields)
  - Renamed classes for clarity: `ExceptionStrategy` → `SchemaBasedErrorStrategy`, `CustomGraphqlExceptionHandler` → `TopLevelErrorHandler`, etc.
  - Added comprehensive documentation in `graphitron-common/README.md`
  - Added integration tests with approval testing in graphitron-example-server

  **Breaking changes:** Class renames require updates to existing implementations.

