### PR TITLE
Add integration test on empty splitQuery lists

### DIFF
--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_empty_list-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_splitQuery_empty_list-1.result.approved.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "languages": {
+            "nodes": [
+                {
+                    "films": {
+                        "nodes": [
+                            
+                        ]
+                    },
+                    "filmsWithoutPagination": [
+                        
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_empty_list.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_splitQuery_empty_list.graphql
@@ -1,0 +1,14 @@
+{
+    languages(first: 1, after: "WzFd") {
+        nodes {
+            films {
+                nodes {
+                    id
+                }
+            }
+            filmsWithoutPagination {
+                id
+            }
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
@@ -138,6 +138,7 @@ type Language implements Node @table @node(keyColumns: ["LANGUAGE_ID"]){
     id: ID!
     name: String
     films(releaseYear: Int @field(name: "RELEASE_YEAR")): [Film] @splitQuery @reference(path: [{key: "FILM__FILM_LANGUAGE_ID_FKEY"}]) @asConnection
+    filmsWithoutPagination: [Film] @splitQuery @reference(path: [{key: "FILM__FILM_LANGUAGE_ID_FKEY"}])
 }
 
 type Film implements Node @node @table {


### PR DESCRIPTION
I forbindelse med testing av [GG-45](https://github.com/sikt-no/graphitron/pull/53/) ser jeg at vi mangler integrasjonstest for at vi får `[]` i stedet for `null` for listede splitQuery spørringer.
Legger derfor til testen her med en gang så vi ikke endrer på det!