### PR TITLE
Validate non-root multitable fields are resolvers

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -641,11 +641,18 @@ public class ProcessedDefinitionsValidator {
 
     private void validateMultitableFieldsOutsideRoot() {
         allFields.stream()
-                .filter(GenerationSourceField::isGeneratedWithResolver)
+                .filter(GenerationSourceField::isGenerated)
                 .filter(it -> !it.isRootField())
                 .filter(it -> schema.isObjectWithPreviousTableObject(it.getContainerTypeName()))
                 .filter(schema::isMultiTableField)
                 .forEach(field -> {
+                    if (!field.isResolver()) {
+                        addErrorMessage("'%s.%s' is a multitable field outside root, but is missing the %s directive. " +
+                                        "Multitable queries outside root is only supported for resolver fields.",
+                                field.getContainerTypeName(), field.getName(), SPLIT_QUERY.getName()
+                        );
+                    }
+
                     if (field.hasFieldReferences()) {
                         addErrorMessage(
                                 String.format("'%s.%s' has the %s directive which is not supported on multitable queries outside root.",

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/MultitableTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/MultitableTest.java
@@ -66,4 +66,14 @@ public class MultitableTest extends ValidationTest {
     void splitQueryReferenceInNestedQuery() {
         getProcessedSchema("splitQueryReferenceInNestedQuery");
     }
+
+    @Test
+    @DisplayName("Multitable query outside root without splitquery should produce validation error")
+    void splitQueryRequiredOnMultitableFieldOutsideRoot() {
+        assertErrorsContain(
+                () -> getProcessedSchema("splitQueryRequiredOnMultitableFieldOutsideRoot"),
+                "'Payment.staffAndCustomers' is a multitable field outside root, but is missing the splitQuery directive. " +
+                        "Multitable queries outside root is only supported for resolver fields"
+        );
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/multitable/splitQueryRequiredOnMultitableFieldOutsideRoot/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/multitable/splitQueryRequiredOnMultitableFieldOutsideRoot/schema.graphqls
@@ -1,0 +1,19 @@
+type Query {
+    query: Payment @notGenerated
+}
+
+type Payment @table {
+    staffAndCustomers: [PersonWithEmail]
+}
+
+interface PersonWithEmail {
+    email: String
+}
+
+type Staff implements PersonWithEmail @table(name: "STAFF") {
+    email: String
+}
+
+type Customer implements PersonWithEmail @table(name: "CUSTOMER") {
+    email: String
+}


### PR DESCRIPTION
Vi støtter ikke multitable felt som subspørringer (m.a.o. at de ikke er resolvere med egne DB-queryer).
Lager derfor valideringstest på dette siden ellers får man en lite hjelpsom` java.util.NoSuchElementException: No value present` uten `@splitQuery`