### PR TITLE
Improved names in TableReflection

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/mapping/JOOQMapping.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/mapping/JOOQMapping.java
@@ -53,19 +53,19 @@ public class JOOQMapping extends MethodMapping implements JoinElement {
 
     public static JOOQMapping fromKey(String keyName) {
         var upperName = keyName.toUpperCase();
-        var sourceTable = getKeySourceTable(upperName);
-        var targetTable = getKeyTargetTable(upperName);
+        var sourceTable = getFkSourceTableForFkJavaFieldName(upperName);
+        var targetTable = getFkTargetTableForFkJavaFieldName(upperName);
 
         return new JOOQMapping(
                 upperName,
-                sourceTable.map(it -> searchTableForKeyMethodName(it, upperName).orElse("")).orElse(""),
+                sourceTable.map(it -> searchTableFieldNameForPathMethodNameGivenFkJavaFieldName(it, upperName).orElse("")).orElse(""),
                 targetTable.map(JOOQMapping::fromTable).orElse(null)
         );
     }
 
     public JOOQMapping getInverseKey() {
-        var sourceTable = getKeySourceTable(name).map(JOOQMapping::fromTable).orElse(null);
-        var targetTable = getKeyTargetTable(name).map(JOOQMapping::fromTable).orElse(null);
+        var sourceTable = getFkSourceTableForFkJavaFieldName(name).map(JOOQMapping::fromTable).orElse(null);
+        var targetTable = getFkTargetTableForFkJavaFieldName(name).map(JOOQMapping::fromTable).orElse(null);
 
         if (sourceTable == null || targetTable == null) {
             return null;
@@ -75,7 +75,7 @@ public class JOOQMapping extends MethodMapping implements JoinElement {
 
         return new JOOQMapping(
                 name,
-                searchTableForKeyMethodName(isReverse ? sourceTable.getName() : targetTable.getName(), name).orElse(""),
+                searchTableFieldNameForPathMethodNameGivenFkJavaFieldName(isReverse ? sourceTable.getName() : targetTable.getName(), name).orElse(""),
                 (isReverse ? targetTable : sourceTable)
         );
     }
@@ -104,13 +104,13 @@ public class JOOQMapping extends MethodMapping implements JoinElement {
 
     public Class<?> getTableClass() {
         // FIXME: Dersom skjema refererer til en tabell som ikke finnes burde vi stoppe genereringen (FSP-538)
-        return TableReflection.getTableClass(name)
+        return TableReflection.getTableClassGivenTableJavaFieldName(name)
                 .orElse(Object.class);
     }
 
     public Class<?> getRecordClass() {
         // FIXME: Dersom skjema refererer til en tabell som ikke finnes burde vi stoppe genereringen (FSP-538)
-        return TableReflection.getRecordClass(name)
+        return TableReflection.getRecordClassGivenTableJavaFieldName(name)
                 .orElse(Object.class);
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/mapping/TableRelation.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/mapping/TableRelation.java
@@ -2,7 +2,7 @@ package no.sikt.graphitron.definitions.mapping;
 
 import no.sikt.graphitron.generators.context.JoinListSequence;
 
-import static no.sikt.graphitron.mappings.TableReflection.inferRelationType;
+import static no.sikt.graphitron.mappings.TableReflection.inferRelationTypeBetweenTableJavaFieldNames;
 
 public class TableRelation {
     private final JOOQMapping from, toTable, key;
@@ -19,7 +19,7 @@ public class TableRelation {
 
         // For cases where relations exist both ways, we need a way to know which one is intended.
         relationType = from != null && toTable != null
-                ? inferRelationType(from.getMappingName(), toTable.getMappingName(), key)
+                ? inferRelationTypeBetweenTableJavaFieldNames(from.getMappingName(), toTable.getMappingName(), key)
                 : TableRelationType.NONE;
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/objects/ObjectDefinition.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/objects/ObjectDefinition.java
@@ -4,17 +4,13 @@ import graphql.language.ObjectTypeDefinition;
 import graphql.language.TypeName;
 import no.sikt.graphitron.definitions.fields.ObjectField;
 import no.sikt.graphitron.definitions.interfaces.GenerationTarget;
-import no.sikt.graphitron.mappings.TableReflection;
 import no.sikt.graphql.directives.GenerationDirective;
-import no.sikt.graphql.directives.GenerationDirectiveParam;
 
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldName;
 import static no.sikt.graphql.directives.DirectiveHelpers.*;
-import static no.sikt.graphql.directives.GenerationDirective.NODE;
 import static no.sikt.graphql.directives.GenerationDirectiveParam.VALUE;
 import static no.sikt.graphql.naming.GraphQLReservedName.SCHEMA_MUTATION;
 import static no.sikt.graphql.naming.GraphQLReservedName.SCHEMA_QUERY;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/objects/RecordObjectDefinition.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/objects/RecordObjectDefinition.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldName;
-import static no.sikt.graphitron.mappings.TableReflection.getRequiredFields;
+import static no.sikt.graphitron.mappings.TableReflection.javaFieldNameForJooqFieldNameInTableJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.getRequiredFieldsForTableJavaFieldName;
 import static no.sikt.graphql.directives.DirectiveHelpers.*;
 import static no.sikt.graphql.directives.GenerationDirective.*;
 import static no.sikt.graphql.directives.GenerationDirectiveParam.NAME;
@@ -61,7 +61,7 @@ public abstract class RecordObjectDefinition<T extends TypeDefinition<T>, U exte
         } else {
             classReference = null;
         }
-        requiredInputs = hasTable() ? getRequiredFields(getTable().getMappingName()).stream().map(String::toUpperCase).collect(Collectors.toCollection(LinkedHashSet::new)) : new LinkedHashSet<>();
+        requiredInputs = hasTable() ? getRequiredFieldsForTableJavaFieldName(getTable().getMappingName()).stream().map(String::toUpperCase).collect(Collectors.toCollection(LinkedHashSet::new)) : new LinkedHashSet<>();
         inputsSortedByNullability = sortInputsByNullability();
         hasKeys = objectDefinition.hasDirective(FEDERATION_KEY.getName());
         keys = hasKeys ? new EntityKeySet(getRepeatableDirectiveArgumentString(objectDefinition, FEDERATION_KEY.getName(), FEDERATION_KEY_ARGUMENT.getName())) : null;
@@ -72,7 +72,7 @@ public abstract class RecordObjectDefinition<T extends TypeDefinition<T>, U exte
         typeId = typeIdParameter.orElse(hasTable() ? getName() : null);
         keyColumns = getOptionalDirectiveArgumentStringList(objectDefinition, GenerationDirective.NODE, GenerationDirectiveParam.KEY_COLUMNS)
                 .stream()
-                .map(columnName -> getJavaFieldName(getTable().getName(), columnName).orElse(columnName))
+                .map(columnName -> javaFieldNameForJooqFieldNameInTableJavaFieldName(getTable().getName(), columnName).orElse(columnName))
                 .collect(Collectors.toCollection(LinkedList::new));
     }
 
@@ -87,7 +87,7 @@ public abstract class RecordObjectDefinition<T extends TypeDefinition<T>, U exte
      */
     protected boolean isNonNullable(GenerationField field) {
         if (field.isID() && hasTable()) {
-            var idFields = TableReflection.getRequiredFields(getTable().getMappingName()).stream()
+            var idFields = TableReflection.getRequiredFieldsForTableJavaFieldName(getTable().getMappingName()).stream()
                     .map(String::toUpperCase)
                     .collect(Collectors.toList());
             if (!idFields.isEmpty()) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -688,7 +688,7 @@ public class FormatCodeBlocks {
     }
 
     public static CodeBlock getSelectKeyColumn(Key<?> key, String tableName, String aliasVariableName) {
-        return getJavaFieldNamesForKey(tableName, key)
+        return getJavaFieldNamesForKeyInTableJavaFieldName(tableName, key)
                 .stream()
                 .map(it -> CodeBlock.of("$N.$L", aliasVariableName, it))
                 .collect(CodeBlock.joining(", "));
@@ -760,7 +760,7 @@ public class FormatCodeBlocks {
         var sourceTable = targetNodeType.getTable().getName();
 
         var targetNodeIdFields = targetNodeType.hasCustomKeyColumns() ? targetNodeType.getKeyColumns()
-                : getPrimaryKeyForTable(sourceTable)
+                : getPrimaryKeyForTableJavaFieldName(sourceTable)
                 .orElseThrow(() -> new IllegalArgumentException("Cannot find primary key for table " + sourceTable)) // This should be validated and never thrown
                 .getFields()
                 .stream()
@@ -772,12 +772,12 @@ public class FormatCodeBlocks {
                         .filter(fieldName -> fieldName.equalsIgnoreCase(it)).findFirst()
                         .orElseThrow(() -> new IllegalArgumentException("Node ID field " + it + " is not found in foreign key " + fk.getName() + "'s fields."))) // Should never be thrown
                 .map(mapping::get)
-                .map(it -> getJavaFieldName(targetTable, it.getName()).orElseThrow())
+                .map(it -> javaFieldNameForJooqFieldNameInTableJavaFieldName(targetTable, it.getName()).orElseThrow())
                 .collect(Collectors.toCollection(LinkedList::new));
     }
 
     public static CodeBlock staticTableInstanceBlock(String tableName) {
-        var tableClass = getTable(tableName)
+        var tableClass = getTableForTableJavaFieldName(tableName)
                 .orElseThrow(() -> new RuntimeException("Unknown table " + tableName))
                 .getClass();
         return CodeBlock.of("$T.$N", tableClass, tableName);

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/NodeIdReferenceHelpers.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/NodeIdReferenceHelpers.java
@@ -10,7 +10,7 @@ import org.jooq.ForeignKey;
 import java.util.Optional;
 
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.referenceNodeIdColumnsBlock;
-import static no.sikt.graphitron.mappings.TableReflection.findImplicitKey;
+import static no.sikt.graphitron.mappings.TableReflection.findImplicitKeyGivenTableJavaFieldNames;
 import static no.sikt.graphql.naming.GraphQLReservedName.SCHEMA_QUERY;
 
 public class NodeIdReferenceHelpers {
@@ -24,11 +24,11 @@ public class NodeIdReferenceHelpers {
         if (!previousTable.equals(targetTable)) {
             return target.getFieldReferences().stream()
                     .findFirst()
-                    .map(fRef -> fRef.hasKey() ? fRef.getKey().getName() : findImplicitKey(previousTable, fRef.getTable().getName()).orElse(null))
+                    .map(fRef -> fRef.hasKey() ? fRef.getKey().getName() : findImplicitKeyGivenTableJavaFieldNames(previousTable, fRef.getTable().getName()).orElse(null))
                     .stream()
                     .findFirst()
-                    .or(() -> findImplicitKey(previousTable, targetTable))
-                    .flatMap(TableReflection::getForeignKey);
+                    .or(() -> findImplicitKeyGivenTableJavaFieldNames(previousTable, targetTable))
+                    .flatMap(TableReflection::getFkByFkJavaFieldName);
         }
         return Optional.empty();
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/BatchUpdateDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/BatchUpdateDBMethodGenerator.java
@@ -137,8 +137,8 @@ public class BatchUpdateDBMethodGenerator extends DBMethodGenerator<ObjectField>
 
     private List<String> getNodeIdKeyColumnNames(List<String> keyColumns, String tableName) {
         if (keyColumns.isEmpty()) {
-            return TableReflection.getPrimaryKeyForTable(tableName)
-                    .map(it -> TableReflection.getJavaFieldNamesForKey(tableName, it))
+            return TableReflection.getPrimaryKeyForTableJavaFieldName(tableName)
+                    .map(it -> TableReflection.getJavaFieldNamesForKeyInTableJavaFieldName(tableName, it))
                     .orElse(Collections.emptyList());
         } else  {
             return keyColumns;

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/DBClassGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/DBClassGenerator.java
@@ -95,7 +95,7 @@ public class DBClassGenerator extends AbstractSchemaClassGenerator<ObjectDefinit
     }
 
     protected Set<Class<?>> getStaticImports() {
-        return new HashSet<>(TableReflection.getClassFromSchemas("Tables"));
+        return new HashSet<>(TableReflection.getClassFromAllJooqSchemaPackages("Tables"));
     }
 
     @Override

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/EntityDBFetcherMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/EntityDBFetcherMethodGenerator.java
@@ -22,7 +22,7 @@ import static no.sikt.graphitron.generators.codebuilding.NameFormat.asEntityQuer
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.getObjectMapTypeName;
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
-import static no.sikt.graphitron.mappings.TableReflection.getFieldType;
+import static no.sikt.graphitron.mappings.TableReflection.getFieldTypeFromTableJavaFieldName;
 
 /**
  * This class generates the queries needed to resolve entities.
@@ -125,7 +125,7 @@ public class EntityDBFetcherMethodGenerator extends FetchDBMethodGenerator {
                     "$L$L.eq(($T) ",
                     field.getUpperCaseName(),
                     toJOOQEnumConverter(field.getTypeName(), processedSchema),
-                    getFieldType(context.getTargetTable().getName(), field.getUpperCaseName()).map(ClassName::get).orElse(STRING.className)
+                    getFieldTypeFromTableJavaFieldName(context.getTargetTable().getName(), field.getUpperCaseName()).map(ClassName::get).orElse(STRING.className)
             );
         }
         conditionCode.add("$N.get($S))", VAR_INPUT_MAP, key);

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -595,7 +595,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         }
 
         var convertArrayFieldToList = field.isIterableWrapped()
-                && getFieldType(context.getTargetTable().getName(), field.getUpperCaseName()).map(Class::isArray).orElse(false);
+                && getFieldTypeFromTableJavaFieldName(context.getTargetTable().getName(), field.getUpperCaseName()).map(Class::isArray).orElse(false);
 
         return CodeBlock.builder()
                 .add("$L.$N", renderedSource, field.getUpperCaseName())
@@ -1112,7 +1112,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         // Determine default order fields (defaultOrder takes precedence over primary key)
         CodeBlock defaultOrderByFields = defaultOrderIndex.map( index -> {
             ValidationHandler.isTrue(
-                    TableReflection.tableHasIndex(tableName, defaultOrderIndex.get()),
+                    TableReflection.tableForTableJavaFieldNameHasIndex(tableName, defaultOrderIndex.get()),
                     "Table '%s' has no index '%s' specified in @defaultOrder for field '%s'",
                     tableName, defaultOrderIndex.get(), referenceField.getName()
             );

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -163,7 +163,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
     protected CodeBlock generateCorrelatedSubquery(GenerationField field, FetchContext context) {
         var isConnection = ((ObjectField) field).hasForwardPagination();
         var isMultiset = field.isIterableWrapped() || isConnection;
-        var orderByFieldsBlock = field.isResolver() && tableHasPrimaryKey(context.getTargetTableName())
+        var orderByFieldsBlock = field.isResolver() && tableJavaFieldNameHasPrimaryKey(context.getTargetTableName())
                 ? CodeBlock.of(VAR_ORDER_FIELDS)
                 : createOrderFieldsBlock((ObjectField) field, context.getTargetAlias(), context.getTargetTableName());
         var shouldBeOrdered = isMultiset && !orderByFieldsBlock.isEmpty();
@@ -315,7 +315,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
         var imports = GeneratorConfig.getExternalReferenceImports();
 
         Optional<String> reference = imports.stream()
-                .filter(it -> getMethodFromReference(it, tableName, field.getName()).isPresent())
+                .filter(it -> getMethodFromReferenceClassForTableJavaFieldName(it, tableName, field.getName()).isPresent())
                 .findFirst();
 
         if (reference.isEmpty()) {
@@ -606,9 +606,9 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
 
     private CodeBlock generateGetForID(MethodMapping mapping, JOOQMapping table) {
         if (table != null) { // This may become superfluous if nodeId becomes the only way of handling IDs. This is just temporary insurance that the right thing gets picked.
-            var method = searchTableForMethodWithName(table.getMappingName(), mapping.getName())
-                    .or(() -> searchTableForMethodWithName(table.getMappingName(), mapping.asGet()))
-                    .or(() -> searchTableForMethodWithName(table.getMappingName(), mapping.asCamelGet()));
+            var method = searchTableJavaFieldNameForMethodName(table.getMappingName(), mapping.getName())
+                    .or(() -> searchTableJavaFieldNameForMethodName(table.getMappingName(), mapping.asGet()))
+                    .or(() -> searchTableJavaFieldNameForMethodName(table.getMappingName(), mapping.asCamelGet()));
             if (method.isPresent()) {
                 return CodeBlock.of(".$L()", method.get());
             }
@@ -619,10 +619,10 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
     private CodeBlock generateHasForID(MethodMapping mapping, JOOQMapping table, CodeBlock content, boolean isIterable) {
         if (table != null) { // This may become superfluous if nodeId becomes the only way of handling IDs. This is just temporary insurance that the right thing gets picked.
             var suffix = isIterable ? "s" : "";
-            if (searchTableForMethodWithName(table.getMappingName(), mapping.asHas() + suffix).isPresent()) {
+            if (searchTableJavaFieldNameForMethodName(table.getMappingName(), mapping.asHas() + suffix).isPresent()) {
                 return mapping.asHasCall(content, isIterable);
             }
-            if (searchTableForMethodWithName(table.getMappingName(), mapping.asCamelHas() + suffix).isPresent()) {
+            if (searchTableJavaFieldNameForMethodName(table.getMappingName(), mapping.asCamelHas() + suffix).isPresent()) {
                 return mapping.asCamelHasCall(content, isIterable);
             }
         }
@@ -860,12 +860,12 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 } else {
                     tupleVariableBlocks.add(
                             isNullableAndNotVirtual
-                                    ? ofTernary(argumentSelect, val(unpacked), makeTupleBlock(field, context, condition.hasRecord(), fieldTypeIsCLOB(lastTable.getName(), field.getUpperCaseName())))
+                                    ? ofTernary(argumentSelect, val(unpacked), makeTupleBlock(field, context, condition.hasRecord(), jooqFieldInTableJavaFieldNameIsClob(lastTable.getName(), field.getUpperCaseName())))
                                     : val(unpacked)
                     );
                 }
 
-                tupleFieldBlocks.add(makeTupleBlock(field, context, condition.hasRecord(), fieldTypeIsCLOB(lastTable.getName(), field.getUpperCaseName())));
+                tupleFieldBlocks.add(makeTupleBlock(field, context, condition.hasRecord(), jooqFieldInTableJavaFieldNameIsClob(lastTable.getName(), field.getUpperCaseName())));
                 selectedConditions.add(condition);
             }
 
@@ -996,7 +996,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                         && !processedSchema.isInsertMutationWithReturning(referenceField);
 
                 var innerFields = isMutationWithJDBCBatching ?
-                        getPrimaryKeyForTable(processedSchema.getRecordType(inputField).getTable().getName())
+                        getPrimaryKeyForTableJavaFieldName(processedSchema.getRecordType(inputField).getTable().getName())
                                 .map(it -> it.getFields().stream().map(col -> new VirtualInputField(col.getName(), inputField.getContainerTypeName())).toList())
                                 .orElse(List.of())
                         : processedSchema.getInputType(inputField).getFields();
@@ -1102,7 +1102,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
     protected CodeBlock createOrderFieldsBlock(ObjectField referenceField, String actualRefTable, String tableName) {
         var orderByField = referenceField.getOrderField();
         var defaultOrderIndex = referenceField.getDefaultOrderIndex();
-        var hasPrimaryKey = tableHasPrimaryKey(tableName);
+        var hasPrimaryKey = tableJavaFieldNameHasPrimaryKey(tableName);
 
         // No sorting possible if no orderBy, no defaultOrder, and no primary key
         if (orderByField.isEmpty() && defaultOrderIndex.isEmpty() && !hasPrimaryKey) {
@@ -1144,7 +1144,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 .stream()
                 .collect(Collectors.toMap(AbstractField::getName, FetchDBMethodGenerator::getIndexName));
 
-        orderByFieldToDBIndexName.forEach((orderByField, indexName) -> ValidationHandler.isTrue(TableReflection.tableHasIndex(targetTableName, indexName),
+        orderByFieldToDBIndexName.forEach((orderByField, indexName) -> ValidationHandler.isTrue(TableReflection.tableForTableJavaFieldNameHasIndex(targetTableName, indexName),
                 "Table '%S' has no index '%S' necessary for sorting by '%s'", targetTableName, indexName, orderByField));
 
         var sortFieldMapEntries = orderByFieldToDBIndexName.entrySet()

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMappedObjectDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMappedObjectDBMethodGenerator.java
@@ -22,7 +22,7 @@ import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.inferFie
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.javapoet.CodeBlock.empty;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
-import static no.sikt.graphitron.mappings.TableReflection.tableHasPrimaryKey;
+import static no.sikt.graphitron.mappings.TableReflection.tableJavaFieldNameHasPrimaryKey;
 import static no.sikt.graphql.naming.GraphQLReservedName.FEDERATION_ENTITIES_FIELD;
 
 /**
@@ -149,7 +149,7 @@ public class FetchMappedObjectDBMethodGenerator extends FetchDBMethodGenerator {
                 .addIf(!lookupExists, "$1L -> $1N.value1().valuesRow(), ", VAR_RECORD_ITERATOR);
 
         if (processedSchema.isObjectOrConnectionNodeWithPreviousTableObject(referenceField.getContainerTypeName()) && referenceField.isIterableWrapped() && !lookupExists || referenceField.hasForwardPagination()) {
-            if (referenceField.hasForwardPagination() && (referenceField.getOrderField().isPresent() || tableHasPrimaryKey(refObject.getTable().getName()))) {
+            if (referenceField.hasForwardPagination() && (referenceField.getOrderField().isPresent() || tableJavaFieldNameHasPrimaryKey(refObject.getTable().getName()))) {
                 return code.addStatement("$1L -> $1N.value2().map($2T::value2))", VAR_RECORD_ITERATOR, RECORD2.className).build();
             }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMultiTableDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchMultiTableDBMethodGenerator.java
@@ -30,8 +30,8 @@ import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
 import static no.sikt.graphitron.generators.db.FetchSingleTableInterfaceDBMethodGenerator.TOKEN;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.SELECT_JOIN_STEP;
-import static no.sikt.graphitron.mappings.TableReflection.getPrimaryKeyForTable;
-import static no.sikt.graphitron.mappings.TableReflection.getTableClass;
+import static no.sikt.graphitron.mappings.TableReflection.getPrimaryKeyForTableJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.getTableClassGivenTableJavaFieldName;
 import static no.sikt.graphitron.validation.ValidationHandler.addErrorMessageAndThrow;
 import static no.sikt.graphql.naming.GraphQLReservedName.*;
 
@@ -301,7 +301,7 @@ public class FetchMultiTableDBMethodGenerator extends FetchDBMethodGenerator {
                     .flatMap(it -> it.getAliasSet().stream().findFirst())
                     .ifPresent(startAlias ->
                             methodBuilder.addParameter(
-                                    getTableClass(startAlias.getAlias().getTable().getName()).orElseThrow(),
+                                    getTableClassGivenTableJavaFieldName(startAlias.getAlias().getTable().getName()).orElseThrow(),
                                     aliasPrefix(startAlias.getAlias().getMappingName())
                             )
                     );
@@ -411,7 +411,7 @@ public class FetchMultiTableDBMethodGenerator extends FetchDBMethodGenerator {
     private static CodeBlock getPrimaryKeyFields(String tableName, String alias) {
         var code = CodeBlock.builder();
 
-        getPrimaryKeyForTable(tableName)
+        getPrimaryKeyForTableJavaFieldName(tableName)
                 .map(pk -> pk
                         .getFields()
                         .stream().map(Field::getName)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/UpdateWithReturningDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/UpdateWithReturningDBMethodGenerator.java
@@ -27,7 +27,7 @@ import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.inputPrefix;
 import static no.sikt.graphitron.generators.context.NodeIdReferenceHelpers.getForeignKeyForNodeIdReference;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.SELECTION_SET;
-import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.javaFieldNameForJooqFieldNameInTableJavaFieldName;
 
 /**
  * Generator that creates the default data mutation methods.
@@ -129,7 +129,7 @@ public class UpdateWithReturningDBMethodGenerator extends FetchDBMethodGenerator
                 }
 
                 for (String keyColumn : keyColumns) {
-                    var field = tableFieldCodeBlock(targetTable, getJavaFieldName(targetTable, keyColumn).orElseThrow());
+                    var field = tableFieldCodeBlock(targetTable, javaFieldNameForJooqFieldNameInTableJavaFieldName(targetTable, keyColumn).orElseThrow());
                     var setValue = val(
                             CodeBlock.of("$N.$L()",
                                 recordInput.isIterableWrapped() ? VAR_ITERATOR : recordInputVariableName,

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/TableReflection.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/TableReflection.java
@@ -13,31 +13,30 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
  * Helper class that takes care of any table reflection operations the code generator might require towards the jOOQ source.
  */
 public class TableReflection {
-    private final static Map<String, Table<?>> TABLES_BY_JAVA_FIELD_NAME = getTablesByJavaFieldName();
-    private final static Map<String, String> TABLE_NAME_TO_JAVA_FIELD_NAME = TABLES_BY_JAVA_FIELD_NAME.entrySet().stream()
+    private final static Map<String, Table<?>> TABLE_JAVA_FIELD_NAME__TO__TABLE = getTableJavaFieldName_to_table();
+    private final static Map<String, String> TABLE_NAME__TO__TABLE_JAVA_FIELD_NAME = TABLE_JAVA_FIELD_NAME__TO__TABLE.entrySet().stream()
             .collect(Collectors.toMap(it -> it.getValue().getName(), Map.Entry::getKey));
-    private final static Map<String, ForeignKey<?, ?>> FOREIGN_KEYS_BY_JAVA_FIELD_NAME = getForeignKeysByJavaFieldName();
-    private final static Map<String, String> FOREIGN_KEY_NAME_TO_JAVA_FIELD_NAME = FOREIGN_KEYS_BY_JAVA_FIELD_NAME.entrySet().stream()
+    private final static Map<String, ForeignKey<?, ?>> FK_JAVA_FIELD_NAME__TO__FK = getFkJavaFieldName_to_Fk();
+    private final static Map<String, String> FK_NAME__TO__FK_JAVA_FIELD_NAME = FK_JAVA_FIELD_NAME__TO__FK.entrySet().stream()
             .collect(Collectors.toMap(it -> it.getValue().getName(), Map.Entry::getKey));
 
-    private final static Map<String, Map<String, String>> PATH_BY_TABLE_AND_KEY = getPathMethodsForTableAndKey(TABLES_BY_JAVA_FIELD_NAME);
+    private final static Map<String, Map<String, String>> TABLE_JAVA_FIELD_NAME__TO__FK_JAVA_FIELD_NAME__TO__PATH_JAVA_METHOD_NAME = tableJavaFieldName_to_fkJavaFieldName_to_pathJavaMethodName();
 
     /**
      * @return The implicit key between these two tables.
      */
-    public static Optional<String> findImplicitKey(String leftTableName, String rightTableName) {
-        var keysOptional = getForeignKeysBetweenTables(leftTableName, rightTableName);
+    public static Optional<String> findImplicitKeyGivenTableJavaFieldNames(String leftTableJavaFieldName, String rightTableJavaFieldName) {
+        var keysOptional = getForeignKeysBetweenTablesGivenTableJavaFieldNames(leftTableJavaFieldName, rightTableJavaFieldName);
         if (keysOptional.isPresent()) {
             var keys = keysOptional.get();
             if (keys.size() == 1) {
-                return Optional.of(FOREIGN_KEY_NAME_TO_JAVA_FIELD_NAME.get(keys.get(0).getName()));
+                return Optional.of(FK_NAME__TO__FK_JAVA_FIELD_NAME.get(keys.get(0).getName()));
             }
         }
         return Optional.empty();
@@ -46,9 +45,9 @@ public class TableReflection {
     /*
     * @return an Optional list of foreign keys between leftTable and rightTable
     * */
-    public static Optional<List<? extends ForeignKey<?, ?>>> getForeignKeysBetweenTables(String leftTableName, String rightTableName) {
-        var leftTable = getTable(leftTableName).orElse(null);
-        var rightTable = getTable(rightTableName).orElse(null);
+    public static Optional<List<? extends ForeignKey<?, ?>>> getForeignKeysBetweenTablesGivenTableJavaFieldNames(String leftTableJavaFieldName, String rightTableJavaFieldName) {
+        var leftTable = getTableForTableJavaFieldName(leftTableJavaFieldName).orElse(null);
+        var rightTable = getTableForTableJavaFieldName(rightTableJavaFieldName).orElse(null);
         if (leftTable == null || rightTable == null) {
             return Optional.empty();
         }
@@ -61,8 +60,8 @@ public class TableReflection {
     /*
     * @return the number of foreign keys between leftTable and rightTable.
     * */
-    public static int getNumberOfForeignKeysBetweenTables(String leftTableName, String rightTableName) {
-        return getForeignKeysBetweenTables(leftTableName,rightTableName)
+    public static int getNumberOfForeignKeysBetweenTablesGivenTableJavaFieldNames(String leftTableJavaFieldName, String rightTableJavaFieldName) {
+        return getForeignKeysBetweenTablesGivenTableJavaFieldNames(leftTableJavaFieldName,rightTableJavaFieldName)
                 .map(List::size)
                 .orElse(0);
     }
@@ -70,12 +69,12 @@ public class TableReflection {
     /**
      * @return The kind of relation that is present between these tables.
      */
-    public static TableRelationType inferRelationType(String leftTableName, String rightTableName, JOOQMapping preferredKey) {
-        var leftTable = getTable(leftTableName);
+    public static TableRelationType inferRelationTypeBetweenTableJavaFieldNames(String leftTableJavaFieldName, String rightTableJavaFieldName, JOOQMapping preferredKey) {
+        var leftTable = getTableForTableJavaFieldName(leftTableJavaFieldName);
         if (leftTable.isEmpty()) {
             return TableRelationType.NONE;
         }
-        var rightTable = getTable(rightTableName);
+        var rightTable = getTableForTableJavaFieldName(rightTableJavaFieldName);
         if (rightTable.isEmpty()) {
             return TableRelationType.NONE;
         }
@@ -95,7 +94,7 @@ public class TableReflection {
 
             // The unlikely case where there are single references both ways, and for some reason the reverse reference is preferred.
             if (reverseKeysSize == 1) {
-                var reverseKeyFieldName = FOREIGN_KEY_NAME_TO_JAVA_FIELD_NAME.get(reverseKeys.get(0).getName());
+                var reverseKeyFieldName = FK_NAME__TO__FK_JAVA_FIELD_NAME.get(reverseKeys.get(0).getName());
                 if (reverseKeyFieldName.equals(preferredKey.getMappingName())) {
                     return TableRelationType.REVERSE_IMPLICIT;
                 }
@@ -122,15 +121,15 @@ public class TableReflection {
     /**
      * @return Does this table have any references to itself?
      */
-    public static boolean hasSelfRelation(String tableName) {
-        return !inferRelationType(tableName, tableName, null).equals(TableRelationType.NONE);
+    public static boolean hasSelfRelation(String tableJavaFieldName) {
+        return !inferRelationTypeBetweenTableJavaFieldNames(tableJavaFieldName, tableJavaFieldName, null).equals(TableRelationType.NONE);
     }
 
     /**
      * NEW FS hack! Some methods do not use getId(), but getId_() methods for ID...
      */
-    public static boolean recordUsesFSHack(String tableName) {
-        return getRecordClass(tableName)
+    public static boolean recordUsesFSHack(String tableJavaFieldName) {
+        return getRecordClassGivenTableJavaFieldName(tableJavaFieldName)
                 .map(it -> Stream.of(it.getMethods()).anyMatch(m -> m.getName().equalsIgnoreCase("getId_")))
                 .orElse(false);
     }
@@ -138,65 +137,43 @@ public class TableReflection {
     /**
      * @return Does this table exist in the generated jOOQ code?
      */
-    public static boolean tableExists(String tableName) {
-        return TABLES_BY_JAVA_FIELD_NAME.containsKey(tableName);
+    public static boolean tableJavaFieldNameExists(String tableJavaFieldName) {
+        return TABLE_JAVA_FIELD_NAME__TO__TABLE.containsKey(tableJavaFieldName);
     }
 
     /**
      * @return Does this key exist in the generated jOOQ code?
      */
-    public static boolean keyExists(String keyName) {
-        return FOREIGN_KEYS_BY_JAVA_FIELD_NAME.containsKey(keyName);
+    public static boolean fkJavaFieldNameExists(String fkJavaFieldName) {
+        return FK_JAVA_FIELD_NAME__TO__FK.containsKey(fkJavaFieldName);
     }
 
     /**
      * @return Does this table or key exist in the generated jOOQ code?
      */
-    public static boolean tableOrKeyExists(String name) {
-        return tableExists(name) || keyExists(name);
+    public static boolean tableOrFkJavaFieldNameExists(String javaFieldName) {
+        return tableJavaFieldNameExists(javaFieldName) || fkJavaFieldNameExists(javaFieldName);
     }
 
     /**
      * @return Which table does this key point to?
      */
-    public static Optional<String> getKeyTargetTable(String keyName) {
-        return getForeignKey(keyName).map(it -> it.getKey().getTable().getName().toUpperCase());
+    public static Optional<String> getFkTargetTableForFkJavaFieldName(String fkJavaFieldName) {
+        return getFkByFkJavaFieldName(fkJavaFieldName).map(it -> it.getKey().getTable().getName().toUpperCase());
     }
 
     /**
      * @return Which table does this key belong to?
      */
-    public static Optional<String> getKeySourceTable(String keyName) {
-        return getForeignKey(keyName).map(it -> it.getTable().getName().toUpperCase());
-    }
-
-    public static Optional<Map<TableField<?, ?>, TableField<?, ?>>> getKeyFields(JOOQMapping key) {
-        if(key == null || key.getMappingName() == null) {
-            return Optional.empty();
-        }
-
-        var keyName = key.getMappingName();
-        var fromColumns = getForeignKey(keyName).map(Key::getFields);
-        var toColumns = getForeignKey(keyName).map(ForeignKey::getKeyFields);
-
-        if(fromColumns.isEmpty() || toColumns.isEmpty()) {
-            return Optional.empty();
-        }
-
-        if(fromColumns.get().size() != toColumns.get().size()) {
-            return Optional.empty();
-        }
-        Map<TableField<?, ?>, TableField<?, ?>> map = IntStream.range(0, fromColumns.get().size())
-                .boxed()
-                .collect(Collectors.toMap(fromColumns.get()::get, toColumns.get()::get));
-        return Optional.of(map);
+    public static Optional<String> getFkSourceTableForFkJavaFieldName(String fkJavaFieldName) {
+        return getFkByFkJavaFieldName(fkJavaFieldName).map(it -> it.getTable().getName().toUpperCase());
     }
 
     /**
      * @return Set of the names for all the fields that are set as required in the jOOQ table.
      */
-    public static Set<String> getRequiredFields(String tableName) {
-        return getTable(tableName)
+    public static Set<String> getRequiredFieldsForTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
                 .map(table -> table.fieldStream()
                         .filter(field -> !field.getDataType().nullable())
                         .map(Field::getName)
@@ -205,22 +182,11 @@ public class TableReflection {
     }
 
     /**
-     * @return Is this field nullable in the jOOQ table?.
-     */
-    public static Optional<Boolean> fieldIsNullable(String tableName, String fieldName) {
-        return getTable(tableName)
-                .map(table -> table
-                        .fieldStream()
-                        .filter(it -> it.getName().equalsIgnoreCase(fieldName))
-                        .anyMatch(it -> it.getDataType().nullable()));
-    }
-
-    /**
      * @return Does this field have a default value in this jOOQ table? Does not work for views.
      */
-    public static boolean tableFieldHasDefaultValue(String tableName, String fieldName) {
-        return getTable(tableName)
-                .flatMap(value -> Arrays.stream(value.fields()).filter(it -> it.getName().equalsIgnoreCase(fieldName)).findFirst())
+    public static boolean jooqFieldNameForTableJavaFieldNameHasDefaultValue(String tableJavaFieldName, String jooqFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
+                .flatMap(value -> Arrays.stream(value.fields()).filter(it -> it.getName().equalsIgnoreCase(jooqFieldName)).findFirst())
                 .map(it -> it.getDataType().defaulted()) // This does not work for views.
                 .orElse(false);
     }
@@ -228,141 +194,137 @@ public class TableReflection {
     /**
      * Checks if a table has an index with the specified name.
      *
-     * @param tableName The name of the table to check for the index.
-     * @param indexName The name of the index
+     * @param tableJavaFieldName The name of the table to check for the index.
+     * @param jooqIndexName The name of the index
      * @return Returns true if the table has an index with the same name as provided, false otherwise.
      */
-    public static boolean tableHasIndex(String tableName, String indexName) {
-        return getIndex(tableName, indexName).isPresent();
-    }
-
-    public static Optional<Index> getIndex(String tableName, String indexName) {
-        return getTable(tableName)
+    public static boolean tableForTableJavaFieldNameHasIndex(String tableJavaFieldName, String jooqIndexName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
                 .flatMap(table -> table.getIndexes().stream()
-                        .filter(index -> index.getName().equalsIgnoreCase(indexName))
-                        .findFirst());
+                        .filter(index -> index.getName().equalsIgnoreCase(jooqIndexName))
+                        .findFirst()).isPresent();
     }
 
     /**
-     * Search this jOOQ table for a method that matches this name.
-     * @param tableName Name of the jOOQ table.
-     * @param name Name that might have a method associated with it.
-     * @return The name of a method that matches the provided name if it exists.
+     * Search this jOOQ table for a method that matches this methodName.
+     * @param tableJavaFieldName Name of the jOOQ table.
+     * @param methodName Name that might have a method associated with it.
+     * @return The methodName of a method that matches the provided methodName if it exists.
      */
-    public static Optional<String> searchTableForMethodWithName(String tableName, String name) {
-        return searchTableForKeyMethodName(tableName, name)
-                .or(() -> getMethodName(tableName, name));
+    public static Optional<String> searchTableJavaFieldNameForMethodName(String tableJavaFieldName, String methodName) {
+        return searchTableFieldNameForPathMethodNameGivenFkJavaFieldName(tableJavaFieldName, methodName)
+                .or(() -> getMethodNameFromTableJavaFieldName(tableJavaFieldName, methodName));
     }
 
     @NotNull
-    private static Optional<String> getMethodName(String tableName, String name) {
-        return getMethod(tableName, name)
+    private static Optional<String> getMethodNameFromTableJavaFieldName(String tableJavaFieldName, String methodName) {
+        return getMethodFromTableJavaFieldName(tableJavaFieldName, methodName)
                 .map(Method::getName);
     }
 
     @NotNull
-    private static Optional<Method> getMethod(String tableName, String name) {
-        return getTable(tableName)
-                .flatMap(table -> Arrays.stream(table.getClass().getMethods()).filter(it -> name.equals(it.getName())).findFirst());
+    private static Optional<Method> getMethodFromTableJavaFieldName(String tableJavaFieldName, String methodName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
+                .flatMap(table -> Arrays.stream(table.getClass().getMethods()).filter(it -> methodName.equals(it.getName())).findFirst());
     }
 
     /**
      * Search this jOOQ table for a path method that matches the provided key name.
-     * @param tableName Name of the jOOQ Table
-     * @param keyName   Name of the jOOQ ForeignKey
+     * @param tableJavaFieldName Name of the jOOQ Table field
+     * @param fkJavaFieldName   Name of the jOOQ ForeignKey
      * @return The name of a path method on the table that matches the provided key
      */
-    public static Optional<String> searchTableForKeyMethodName(String tableName, String keyName) {
-        var keys = PATH_BY_TABLE_AND_KEY.get(tableName);
+    public static Optional<String> searchTableFieldNameForPathMethodNameGivenFkJavaFieldName(String tableJavaFieldName, String fkJavaFieldName) {
+        var keys = TABLE_JAVA_FIELD_NAME__TO__FK_JAVA_FIELD_NAME__TO__PATH_JAVA_METHOD_NAME.get(tableJavaFieldName);
         if (keys != null) {
-            var name = keys.get(keyName);
+            var name = keys.get(fkJavaFieldName);
             return Optional.ofNullable(name);
         }
 
         return Optional.empty();
     }
 
-    public static Optional<Table<?>> getTable(String name) {
-        return Optional.ofNullable(TABLES_BY_JAVA_FIELD_NAME.get(name));
+    public static Optional<Table<?>> getTableForTableJavaFieldName(String tableJavafieldName) {
+        return Optional.ofNullable(TABLE_JAVA_FIELD_NAME__TO__TABLE.get(tableJavafieldName));
     }
 
-    public static Optional<ForeignKey<?, ?>> getForeignKey(String name) {
-        return Optional.ofNullable(FOREIGN_KEYS_BY_JAVA_FIELD_NAME.get(name));
+    public static Optional<ForeignKey<?, ?>> getFkByFkJavaFieldName(String fkJavafieldName) {
+        return Optional.ofNullable(FK_JAVA_FIELD_NAME__TO__FK.get(fkJavafieldName));
     }
 
     /**
      * @return Set of field names for this table.
      */
-    public static Set<String> getJavaFieldNamesForTable(String tableName) {
-        return getTable(tableName)
+    public static Set<String> getJavaFieldNamesForTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
                 .map(table -> Arrays.stream(table.getClass().getFields())
-                        .map(TableReflection::getJavaFieldName)
+                        .map(field -> field.getName())
                         .collect(Collectors.toSet()))
                 .orElse(Set.of());
     }
 
-    public static List<String> getJavaFieldNamesForKey(String tableName, Key<?> key) {
+    public static List<String> getJavaFieldNamesForKeyInTableJavaFieldName(String tableJavaFieldName, Key<?> key) {
         return key.getFields()
                 .stream()
                 .map(keyField ->
-                        getJavaFieldName(tableName, keyField.getName())
+                        javaFieldNameForJooqFieldNameInTableJavaFieldName(tableJavaFieldName, keyField.getName())
                                 .orElseThrow())
                 .toList();
     }
 
-    public static Optional<String> getJavaFieldName(String tableName, String fieldName) {
-        return getJavaFieldNamesForTable(tableName)
+    public static Optional<String> javaFieldNameForJooqFieldNameInTableJavaFieldName(String tableJavaFieldName, String jooqFieldName) {
+        return getJavaFieldNamesForTableJavaFieldName(tableJavaFieldName)
                 .stream()
-                .filter(tableFieldName -> tableFieldName.equalsIgnoreCase(fieldName))
+                .filter(tableFieldName -> tableFieldName.equalsIgnoreCase(jooqFieldName))
                 .findFirst();
     }
 
-    public static Set<Class<?>> getClassFromSchemas(String className) {
+    public static Set<Class<?>> getClassFromAllJooqSchemaPackages(String className) {
         return getDefaultCatalog()
                 .schemaStream()
-                .map(getClassFromSchemaPackage(className))
+                .map(getClassFromJooqSchemaPackage(className))
                 .collect(Collectors.toSet());
     }
 
-    protected static Map<String, Table<?>> getTablesByJavaFieldName() {
+    protected static Map<String, Table<?>> getTableJavaFieldName_to_table() {
         return getDefaultCatalog()
                 .schemaStream()
-                .flatMap(getFieldsFromSchemaClass("Tables"))
+                .flatMap(getFieldsFromJooqSchemaClass("Tables"))
                 .filter(it -> Table.class.isAssignableFrom(it.getType()))
                 .collect(Collectors.toMap(
-                        TableReflection::getJavaFieldName,
+                        field -> field.getName(),
                         it -> (Table<?>) getJavaFieldValue(it)));
     }
 
-    protected static Map<String, ForeignKey<?, ?>> getForeignKeysByJavaFieldName() {
+    protected static Map<String, ForeignKey<?, ?>> getFkJavaFieldName_to_Fk() {
         return getDefaultCatalog()
                 .schemaStream()
-                .flatMap(getFieldsFromSchemaClass("Keys"))
+                .flatMap(getFieldsFromJooqSchemaClass("Keys"))
                 .filter(it -> ForeignKey.class.isAssignableFrom(it.getType()))
                 .collect(Collectors.toMap(
-                        TableReflection::getJavaFieldName,
+                        field -> field.getName(),
                         it -> (ForeignKey<?, ?>) getJavaFieldValue(it)));
     }
 
     /**
      * @return Map containing all the foreign key references for any table and the corresponding method names to call them.
      */
-    private static Map<String, Map<String, String>> getPathMethodsForTableAndKey(Map<String, Table<?>> tablesByJavaFieldName) {
-        return tablesByJavaFieldName
+    private static Map<String, Map<String, String>> tableJavaFieldName_to_fkJavaFieldName_to_pathJavaMethodName() {
+        return TableReflection.TABLE_JAVA_FIELD_NAME__TO__TABLE
                 .values()
                 .stream()
-                .collect(Collectors.toMap(table -> TABLE_NAME_TO_JAVA_FIELD_NAME.get(table.getName()), TableReflection::getPathByFk));
+                .collect(Collectors.toMap(table -> TABLE_NAME__TO__TABLE_JAVA_FIELD_NAME.get(table.getName()), TableReflection::keyFieldNameToPathMethodName));
     }
 
     /**
      * @param table Table class to find paths for.
      * @return Map containing all the foreign key references for the table and the corresponding method names to call them.
      */
-    private static Map<String, String> getPathByFk(Table<?> table) {
+    private static Map<String, String> keyFieldNameToPathMethodName(Table<?> table) {
         return Arrays
                 .stream(table.getClass().getMethods())
                 .filter(it -> Path.class.isAssignableFrom(it.getReturnType()))
-                .collect(Collectors.toMap(method -> getKeyNameForMethod(table, method), Method::getName));
+                .collect(Collectors.toMap(method -> getKeyFieldNameForPathMethod(table, method), Method::getName));
     }
 
     /**
@@ -370,50 +332,50 @@ public class TableReflection {
      * @param table Table class to which the method belongs to.
      * @return The jOOQ name of the key corresponding to the method in the table class.
      */
-    private static String getKeyNameForMethod(Table<?> table, Method method) {
+    private static String getKeyFieldNameForPathMethod(Table<?> table, Method method) {
         try {
             var path = (Path<?>) method.invoke(table);
-            var childKey = (ForeignKey<?, ?>) getField(path, "childPath");
-            var parentKey = (InverseForeignKey<?, ?>) getField(path, "parentPath");
+            var childKey = (ForeignKey<?, ?>) getJooqFieldFromTableJavaFieldName(path, "childPath");
+            var parentKey = (InverseForeignKey<?, ?>) getJooqFieldFromTableJavaFieldName(path, "parentPath");
             var key = childKey != null ? childKey : parentKey.getForeignKey();
-            return FOREIGN_KEY_NAME_TO_JAVA_FIELD_NAME.get(key.getName());
+            return FK_NAME__TO__FK_JAVA_FIELD_NAME.get(key.getName());
         } catch (IllegalAccessException | NoSuchFieldException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static Object getField(Path<?> path, String name) throws NoSuchFieldException, IllegalAccessException {
+    private static Object getJooqFieldFromTableJavaFieldName(Path<?> path, String name) throws NoSuchFieldException, IllegalAccessException {
         var childKeyField = TableImpl.class.getDeclaredField(name);
         childKeyField.setAccessible(true);
         return childKeyField.get(path);
     }
 
-    public static Optional<Field<?>> getField(String tableName, String name) {
-        return getTable(tableName)
+    public static Optional<Field<?>> getJooqFieldFromTableJavaFieldName(String tableJavaFieldName, String jooqFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
                 .flatMap(table -> Arrays.stream(table.fields())
-                        .filter(field -> field.getName().equalsIgnoreCase(name))
+                        .filter(field -> field.getName().equalsIgnoreCase(jooqFieldName))
                         .findFirst()
                 );
     }
 
-    public static Optional<Class<?>> getFieldType(String table, String name) {
-        return getField(table, name).map(Typed::getType);
+    public static Optional<Class<?>> getFieldTypeFromTableJavaFieldName(String tableJavaFieldName, String jooqFieldName) {
+        return getJooqFieldFromTableJavaFieldName(tableJavaFieldName, jooqFieldName).map(Typed::getType);
     }
 
-    public static boolean fieldTypeIsCLOB(String table, String name) {
-        return getField(table, name)
+    public static boolean jooqFieldInTableJavaFieldNameIsClob(String tableJavafieldName, String jooqFieldName) {
+        return getJooqFieldFromTableJavaFieldName(tableJavafieldName, jooqFieldName)
                 .flatMap(it -> Optional.ofNullable(it.getDataType().getSQLDataType()))
                 .map(it -> it.equals(SQLDataType.CLOB))
                 .orElse(false);
     }
 
-    private static Function<Schema, Stream<java.lang.reflect.Field>> getFieldsFromSchemaClass(String className) {
-        return getClassFromSchemaPackage(className)
+    private static Function<Schema, Stream<java.lang.reflect.Field>> getFieldsFromJooqSchemaClass(String className) {
+        return getClassFromJooqSchemaPackage(className)
                 .andThen(it -> Arrays.stream(it.getFields()));
     }
 
     @NotNull
-    private static Function<Schema, Class<?>> getClassFromSchemaPackage(String className) {
+    private static Function<Schema, Class<?>> getClassFromJooqSchemaPackage(String className) {
         return schema -> {
             var packageName = schema.getClass().getPackageName();
             try {
@@ -422,10 +384,6 @@ public class TableReflection {
                 throw new RuntimeException(packageName + " did not contain a " + className + " class. Inconceivable.", e);
             }
         };
-    }
-
-    private static String getJavaFieldName(java.lang.reflect.Field field) {
-        return field.getName();
     }
 
     private static Object getJavaFieldValue(java.lang.reflect.Field field) {
@@ -452,47 +410,47 @@ public class TableReflection {
         }
     }
 
-    public static Optional<Class<?>> getTableClass(String name) {
-        return getTable(name).map(Object::getClass);
+    public static Optional<Class<?>> getTableClassGivenTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName).map(Object::getClass);
     }
 
-    public static Optional<Class<?>> getRecordClass(String name) {
-        return getTable(name).map(Table::getRecordType);
+    public static Optional<Class<?>> getRecordClassGivenTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName).map(Table::getRecordType);
     }
 
-    public static boolean tableHasPrimaryKey(String tableName) {
-        return getPrimaryKeyForTable(tableName).isPresent();
+    public static boolean tableJavaFieldNameHasPrimaryKey(String tableJavaFieldName) {
+        return getPrimaryKeyForTableJavaFieldName(tableJavaFieldName).isPresent();
     }
 
-    public static Optional<? extends UniqueKey<?>> getPrimaryKeyForTable(String tableName) {
-        return getTable(tableName).map(Table::getPrimaryKey).stream().findFirst();
+    public static Optional<? extends UniqueKey<?>> getPrimaryKeyForTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName).map(Table::getPrimaryKey).stream().findFirst();
     }
 
-    public static Optional<List<? extends UniqueKey<?>>> getUniqueKeysForTable(String tableName) {
-        return getTable(tableName).map(Table::getUniqueKeys);
+    public static Optional<List<? extends UniqueKey<?>>> getUniqueKeysForTableJavaFieldName(String tableJavaFieldName) {
+        return getTableForTableJavaFieldName(tableJavaFieldName).map(Table::getUniqueKeys);
     }
 
-    public static Set<? extends UniqueKey<?>> getPrimaryAndUniqueKeysForTable(String tableName) {
+    public static Set<? extends UniqueKey<?>> getPrimaryAndUniqueKeysForTableJavaFieldName(String tableJavaFieldName) {
         var allKeys = new HashSet<UniqueKey<?>>();
-        getPrimaryKeyForTable(tableName).map(allKeys::add);
-        getUniqueKeysForTable(tableName).map(allKeys::addAll);
+        getPrimaryKeyForTableJavaFieldName(tableJavaFieldName).map(allKeys::add);
+        getUniqueKeysForTableJavaFieldName(tableJavaFieldName).map(allKeys::addAll);
         return allKeys;
     }
 
-    public static Optional<? extends UniqueKey<?>> getPrimaryOrUniqueKeyMatchingFields(String table, List<String> fields) {
-        return getTable(table)
+    public static Optional<? extends UniqueKey<?>> getPrimaryOrUniqueKeyMatchingColumnNamesForTableJavaFieldName(String tableJavaFieldName, List<String> columnNames) {
+        return getTableForTableJavaFieldName(tableJavaFieldName)
                 .flatMap(value ->
                         Stream.concat(value.getUniqueKeys().stream(), Stream.of(value.getPrimaryKey()))
-                                .filter(key -> key.getFields().size() == fields.size()
-                                        && fields.stream().allMatch(idField -> key.getFields().stream().anyMatch(keyField -> keyField.getName().equalsIgnoreCase(idField))))
+                                .filter(key -> key.getFields().size() == columnNames.size()
+                                        && columnNames.stream().allMatch(idField -> key.getFields().stream().anyMatch(keyField -> keyField.getName().equalsIgnoreCase(idField))))
                                 .findFirst()
                 );
     }
 
-    public static Optional<Method> getMethodFromReference(String reference, String tableName, String methodName) {
+    public static Optional<Method> getMethodFromReferenceClassForTableJavaFieldName(String referenceClassName, String tableJavaFieldName, String methodName) {
         try {
-        Class<?> clazz = Class.forName(reference);
-        Optional<Class<?>> tableClass = getTableClass(tableName);
+        Class<?> clazz = Class.forName(referenceClassName);
+        Optional<Class<?>> tableClass = getTableClassGivenTableJavaFieldName(tableJavaFieldName);
         if (tableClass.isEmpty()) {
             return Optional.empty();
         }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -1691,7 +1691,7 @@ public class ProcessedDefinitionsValidator {
                 .forEach(field -> {
                     var recordType = schema.getRecordType(field);
                     var tableName = recordType.getTable().getMappingName();
-                    if (!tableHasPrimaryKey(tableName)) {
+                    if (!tableJavaFieldNameHasPrimaryKey(tableName)) {
                         var hasDefaultOrder = field.getDefaultOrderIndex().isPresent();
                         var orderByField = field.getOrderField();
                         var hasNonNullableOrderBy = orderByField.isPresent() && orderByField.get().isNonNullable();

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -136,7 +136,7 @@ public class ProcessedDefinitionsValidator {
                         addErrorMessage("Type %s has the %s directive, but is missing the %s directive.",
                                 objectDefinition.getName(), NODE.getName(), TABLE.getName());
                     } else {
-                        var tableFields = getJavaFieldNamesForTable(objectDefinition.getTable().getName());
+                        var tableFields = getJavaFieldNamesForTableJavaFieldName(objectDefinition.getTable().getName());
                         objectDefinition.getKeyColumns().stream()
                                 .filter(col -> tableFields.stream().noneMatch(it -> it.equalsIgnoreCase(col)))
                                 .forEach(col -> addErrorMessage(
@@ -177,8 +177,8 @@ public class ProcessedDefinitionsValidator {
 
     private Optional<? extends UniqueKey<?>> getPrimaryOrUniqueKeyMatchingIdFields(ObjectDefinition target) {
         return !target.hasCustomKeyColumns() ?
-                getPrimaryKeyForTable(target.getTable().getName())
-                : getPrimaryOrUniqueKeyMatchingFields(target.getTable().getName(), target.getKeyColumns());
+                getPrimaryKeyForTableJavaFieldName(target.getTable().getName())
+                : getPrimaryOrUniqueKeyMatchingColumnNamesForTableJavaFieldName(target.getTable().getName(), target.getKeyColumns());
     }
 
     private void validateNodeId() {
@@ -277,7 +277,7 @@ public class ProcessedDefinitionsValidator {
                 .filter(it -> schema.isRecordType(it.getName()))
                 .map(it -> schema.getRecordType(it.getName()))
                 .filter(it -> it.getFields().stream().anyMatch(FieldSpecification::hasNodeID))
-                .filter(it -> it.hasTable() && getTable(it.getTable().getName()).isPresent()) // No need to continue validation here if table does not exist. Table names is validated in validateTablesAndKeys
+                .filter(it -> it.hasTable() && getTableForTableJavaFieldName(it.getTable().getName()).isPresent()) // No need to continue validation here if table does not exist. Table names is validated in validateTablesAndKeys
                 .forEach(jooqRecordInput ->
                         jooqRecordInput.getFields()
                                 .stream()
@@ -330,7 +330,7 @@ public class ProcessedDefinitionsValidator {
                                     }
 
                                     if (isUsedInUpdateMutation(jooqRecordInput)) {
-                                        getPrimaryKeyForTable(jooqRecordInput.getTable().getName())
+                                        getPrimaryKeyForTableJavaFieldName(jooqRecordInput.getTable().getName())
                                                 .map(Key::getFields)
                                                 .filter(it -> it.stream().anyMatch(pkF -> foreignKey.getFields().stream().anyMatch(pkF::equals)))
                                                 .stream().findFirst()
@@ -374,7 +374,7 @@ public class ProcessedDefinitionsValidator {
                 .filter(RecordObjectSpecification::hasTable)
                 .map(RecordObjectSpecification::getTable)
                 .map(JOOQMapping::getMappingName)
-                .filter(it -> !tableExists(it))
+                .filter(it -> !tableJavaFieldNameExists(it))
                 .forEach(it -> addErrorMessage("No table with name \"%s\" found.", it));
 
         var allReferences = recordTypes
@@ -390,7 +390,7 @@ public class ProcessedDefinitionsValidator {
                 .filter(FieldReference::hasTable)
                 .map(FieldReference::getTable)
                 .map(JOOQMapping::getMappingName)
-                .filter(it -> !tableExists(it))
+                .filter(it -> !tableJavaFieldNameExists(it))
                 .forEach(it -> addErrorMessage("No table with name \"%s\" found.", it));
 
         allReferences
@@ -398,7 +398,7 @@ public class ProcessedDefinitionsValidator {
                 .filter(FieldReference::hasKey)
                 .map(FieldReference::getKey)
                 .map(JOOQMapping::getMappingName)
-                .filter(it -> !keyExists(it))
+                .filter(it -> !fkJavaFieldNameExists(it))
                 .forEach(it -> addErrorMessage("No key with name \"%s\" found.", it));
 
         recordTypes
@@ -434,11 +434,11 @@ public class ProcessedDefinitionsValidator {
             } else if (fieldReference.hasKey()) {
                 String nextTable;
                 String keyName = fieldReference.getKey().getName();
-                var keyTarget = getKeyTargetTable(keyName).orElse("");
+                var keyTarget = getFkTargetTableForFkJavaFieldName(keyName).orElse("");
                 if (!keyTarget.equals(sourceTable)) {
                     nextTable = keyTarget;
                 } else {
-                    nextTable = getKeySourceTable(keyName).orElse("");
+                    nextTable = getFkSourceTableForFkJavaFieldName(keyName).orElse("");
                 }
                 if (nextTable.equals(targetTable)) {
                     return;
@@ -465,7 +465,7 @@ public class ProcessedDefinitionsValidator {
     }
 
     private void addErrorMessageAndThrowIfNoImplicitPath(GenerationField field, String leftTable, String rightTable) {
-        var possibleKeys = getNumberOfForeignKeysBetweenTables(leftTable, rightTable);
+        var possibleKeys = getNumberOfForeignKeysBetweenTablesGivenTableJavaFieldNames(leftTable, rightTable);
         if (possibleKeys == 1) return;
 
         var isMultitableField = field instanceof VirtualSourceField;
@@ -512,14 +512,14 @@ public class ProcessedDefinitionsValidator {
         getUsedTablesWithRequiredMethods()
                 .entrySet()
                 .stream()
-                .filter(it -> tableOrKeyExists(it.getKey()))
+                .filter(it -> tableOrFkJavaFieldNameExists(it.getKey()))
                 .forEach(entry -> {
                     var tableName = entry.getKey();
-                    var allFieldNames = getJavaFieldNamesForTable(tableName);
+                    var allFieldNames = getJavaFieldNamesForTableJavaFieldName(tableName);
                     var nonFieldElements = entry.getValue().stream().filter(it -> !allFieldNames.contains(it)).toList();
                     var missingElements = nonFieldElements
                             .stream()
-                            .filter(it -> searchTableForMethodWithName(tableName, it).isEmpty())
+                            .filter(it -> searchTableJavaFieldNameForMethodName(tableName, it).isEmpty())
                             .toList();
 
                     if (!missingElements.isEmpty()) {
@@ -658,7 +658,7 @@ public class ProcessedDefinitionsValidator {
                 var nextTable = reference.hasTable()
                         ? reference.getTable().getMappingName()
                         : (schema.isRecordType(field) ? schema.getObjectOrConnectionNode(field).getTable().getMappingName() : lastTable);
-                var reverseKeyFound = searchTableForMethodWithName(nextTable, key.getMappingName()).isPresent(); // In joins the key can also be used in reverse.
+                var reverseKeyFound = searchTableJavaFieldNameForMethodName(nextTable, key.getMappingName()).isPresent(); // In joins the key can also be used in reverse.
                 requiredJOOQTypesAndMethods
                         .computeIfAbsent(reverseKeyFound ? nextTable : lastTable, (k) -> new HashSet<>())
                         .add(key.getMappingName());
@@ -776,7 +776,7 @@ public class ProcessedDefinitionsValidator {
                     }
 
                     if (!interfaceDefinition.isMultiTableInterface()) { // Single table interface with discriminator
-                        Optional<?> discriminatorField = getField(
+                        Optional<?> discriminatorField = getJooqFieldFromTableJavaFieldName(
                                 interfaceDefinition.getTable().getName(),
                                 interfaceDefinition.getDiscriminatorFieldName()
                         );
@@ -786,7 +786,7 @@ public class ProcessedDefinitionsValidator {
                                                     "does not exist in table '%s'.",
                                             name, interfaceDefinition.getDiscriminatorFieldName(), interfaceDefinition.getTable().getName()));
                         } else {
-                            Optional<Class<?>> fieldType = getFieldType(
+                            Optional<Class<?>> fieldType = getFieldTypeFromTableJavaFieldName(
                                     interfaceDefinition.getTable().getName(),
                                     interfaceDefinition.getDiscriminatorFieldName()
                             );
@@ -931,7 +931,7 @@ public class ProcessedDefinitionsValidator {
                                             if (!implementation.hasTable()) {
                                                 addErrorMessage("Interface '%s' is returned in field '%s', but type '%s' " +
                                                         "implementing '%s' does not have table set. This is not supported.", name, field.getName(), implementation.getName(), name);
-                                            } else if (!tableHasPrimaryKey(implementation.getTable().getName())) {
+                                            } else if (!tableJavaFieldNameHasPrimaryKey(implementation.getTable().getName())) {
                                                 addErrorMessage("Interface '%s' is returned in field '%s', but implementing type '%s' " +
                                                         "has table '%s' which does not have a primary key. This is not supported.", name, field.getName(), implementation.getName(), implementation.getTable().getName());
                                             }
@@ -1315,13 +1315,13 @@ public class ProcessedDefinitionsValidator {
                 );
             }
 
-            var keys = getPrimaryAndUniqueKeysForTable(targetTable.getName());
+            var keys = getPrimaryAndUniqueKeysForTableJavaFieldName(targetTable.getName());
             var nonNullableInputFields = inputType.getFields().stream()
                     .filter(AbstractField::isNonNullable)
                     .toList();
 
             for (var key : keys) {
-                var keyFields = getJavaFieldNamesForKey(targetTable.getName(), key);
+                var keyFields = getJavaFieldNamesForKeyInTableJavaFieldName(targetTable.getName(), key);
                 var keyFieldToInputFieldMatches = keyFields.stream()
                         .collect(Collectors.toMap(
                                 kf -> kf,
@@ -1385,10 +1385,10 @@ public class ProcessedDefinitionsValidator {
         var inputObject = schema.getInputType(recordInput);
         var tableName = inputObject.getTable().getMappingName();
 
-        var requiredDBFields = getRequiredFields(tableName)
+        var requiredDBFields = getRequiredFieldsForTableJavaFieldName(tableName)
                 .stream()
                 .map(String::toUpperCase)
-                .filter(it -> !tableFieldHasDefaultValue(tableName, it)) // No need to complain when it has a default set. Note that this does not work for views.
+                .filter(it -> !jooqFieldNameForTableJavaFieldNameHasDefaultValue(tableName, it)) // No need to complain when it has a default set. Note that this does not work for views.
                 .collect(Collectors.toList());
         var recordFieldNames =
                 inputObject.getFields()
@@ -1465,7 +1465,7 @@ public class ProcessedDefinitionsValidator {
 
                             Set<String> referenceImports = GeneratorConfig.getExternalReferenceImports();
                             List<Method> methods = referenceImports.stream()
-                                    .map(it -> getMethodFromReference(it, table.getName(), field.getName()))
+                                    .map(it -> getMethodFromReferenceClassForTableJavaFieldName(it, table.getName(), field.getName()))
                                     .flatMap(Optional::stream)
                                     .toList();
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphql/schema/ProcessedSchema.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphql/schema/ProcessedSchema.java
@@ -30,8 +30,8 @@ import java.util.stream.Stream;
 import static no.sikt.graphitron.configuration.GeneratorConfig.useJdbcBatchingForDeletes;
 import static no.sikt.graphitron.configuration.GeneratorConfig.useJdbcBatchingForInserts;
 import static no.sikt.graphitron.configuration.Recursion.recursionCheck;
-import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldNamesForKey;
-import static no.sikt.graphitron.mappings.TableReflection.getPrimaryKeyForTable;
+import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldNamesForKeyInTableJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.getPrimaryKeyForTableJavaFieldName;
 import static no.sikt.graphql.naming.GraphQLReservedName.*;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -484,8 +484,8 @@ public class ProcessedSchema {
             return Optional.of(type.getKeyColumns());
         }
 
-        return getPrimaryKeyForTable(type.getTable().getName())
-                .map(f -> new LinkedList<>(getJavaFieldNamesForKey(type.getTable().getName(), f)));
+        return getPrimaryKeyForTableJavaFieldName(type.getTable().getName())
+                .map(f -> new LinkedList<>(getJavaFieldNamesForKeyInTableJavaFieldName(type.getTable().getName(), f)));
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/code/TableReflectionTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/code/TableReflectionTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static no.sikt.graphitron.common.configuration.TestConfiguration.setProperties;
-import static no.sikt.graphitron.mappings.TableReflection.searchTableForKeyMethodName;
-import static no.sikt.graphitron.mappings.TableReflection.searchTableForMethodWithName;
+import static no.sikt.graphitron.mappings.TableReflection.searchTableFieldNameForPathMethodNameGivenFkJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.searchTableJavaFieldNameForMethodName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Reflection - Use reflection on jOOQ code")
@@ -26,27 +26,27 @@ public class TableReflectionTest {
     @Test
     @DisplayName("Can find a method name for a key that exists")
     public void findMethodForExistingKey() {
-        assertThat(searchTableForKeyMethodName("CUSTOMER", "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY")).hasValue("address");
+        assertThat(searchTableFieldNameForPathMethodNameGivenFkJavaFieldName("CUSTOMER", "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY")).hasValue("address");
     }
 
 
     @Test
     @DisplayName("Finds no method if table is provided when key is expected or key does not exist")
     public void findNothingForNotKeys() {
-        assertThat(searchTableForKeyMethodName("RENTAL", "INVENTORY")).isEmpty();
-        assertThat(searchTableForKeyMethodName("RENTAL", "NONEXISTENT")).isEmpty();
+        assertThat(searchTableFieldNameForPathMethodNameGivenFkJavaFieldName("RENTAL", "INVENTORY")).isEmpty();
+        assertThat(searchTableFieldNameForPathMethodNameGivenFkJavaFieldName("RENTAL", "NONEXISTENT")).isEmpty();
     }
 
     @Test
     @DisplayName("Can find a method name for a key or table that exists")
     public void findMethodForExistingKeyOrTable() {
-        assertThat(searchTableForMethodWithName("CUSTOMER", "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY")).hasValue("address");
-        assertThat(searchTableForMethodWithName("RENTAL", "inventory")).hasValue("inventory");
+        assertThat(searchTableJavaFieldNameForMethodName("CUSTOMER", "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY")).hasValue("address");
+        assertThat(searchTableJavaFieldNameForMethodName("RENTAL", "inventory")).hasValue("inventory");
     }
 
     @Test
     @DisplayName("Finds no method if provided value does not exist")
     public void findNothingForInvalidName() {
-        assertThat(searchTableForMethodWithName("RENTAL", "NONEXISTENT")).isEmpty();
+        assertThat(searchTableJavaFieldNameForMethodName("RENTAL", "NONEXISTENT")).isEmpty();
     }
 }


### PR DESCRIPTION
We currently have a bug relating to matching table names with table java method names. This change is there to make it easier to understand what's going on.