### PR TITLE
Replaced one-to-many filter LEFT JOINs with EXISTS subqueries

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/sql/SQLJoinStatement.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/sql/SQLJoinStatement.java
@@ -2,6 +2,7 @@ package no.sikt.graphitron.definitions.sql;
 
 import no.sikt.graphitron.definitions.interfaces.JoinElement;
 import no.sikt.graphitron.definitions.mapping.AliasWrapper;
+import no.sikt.graphitron.definitions.mapping.JOOQMapping;
 import no.sikt.graphitron.generators.context.JoinListSequence;
 import no.sikt.graphitron.javapoet.CodeBlock;
 
@@ -17,6 +18,7 @@ public class SQLJoinStatement extends SQLJoin {
     private final String comparableJoinString;
     private final AliasWrapper joinAlias;
     private final CodeBlock joinString;
+    private final JOOQMapping key;
 
     /**
      * @param joinTargetTable The "right" side of a join statement. This is the table to be joined with.
@@ -24,9 +26,20 @@ public class SQLJoinStatement extends SQLJoin {
      * @param nullable What kind of join operation is to be used.
      */
     public SQLJoinStatement(JoinListSequence joinSequence, JoinElement joinTargetTable, AliasWrapper joinAlias, List<SQLJoinField> joinFields, boolean nullable) {
+        this(joinSequence, joinTargetTable, joinAlias, joinFields, nullable, null);
+    }
+
+    /**
+     * @param joinTargetTable The "right" side of a join statement. This is the table to be joined with.
+     * @param joinFields List of any conditions for the join operation.
+     * @param nullable What kind of join operation is to be used.
+     * @param key The foreign key used for this join, if available. Used to generate EXISTS subqueries for filter-only LEFT JOINs.
+     */
+    public SQLJoinStatement(JoinListSequence joinSequence, JoinElement joinTargetTable, AliasWrapper joinAlias, List<SQLJoinField> joinFields, boolean nullable, JOOQMapping key) {
         super(joinSequence, joinFields, nullable);
         this.joinTargetTable = joinTargetTable;
         this.joinAlias = joinAlias;
+        this.key = key;
         joinString = super.toJoinString(joinAlias.getAlias().getMappingName());
         comparableJoinString = joinString.toString();
     }
@@ -50,6 +63,13 @@ public class SQLJoinStatement extends SQLJoin {
      */
     public AliasWrapper getJoinAlias() {
         return joinAlias;
+    }
+
+    /**
+     * @return The foreign key used for this join, or null if not available.
+     */
+    public JOOQMapping getKey() {
+        return key;
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/FetchContext.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/FetchContext.java
@@ -10,6 +10,7 @@ import no.sikt.graphitron.definitions.mapping.Alias;
 import no.sikt.graphitron.definitions.mapping.AliasWrapper;
 import no.sikt.graphitron.definitions.mapping.JOOQMapping;
 import no.sikt.graphitron.definitions.mapping.TableRelation;
+import no.sikt.graphitron.definitions.mapping.TableRelationType;
 import no.sikt.graphitron.definitions.sql.SQLJoinStatement;
 import no.sikt.graphitron.generators.codebuilding.KeyWrapper;
 import no.sikt.graphitron.javapoet.CodeBlock;
@@ -38,6 +39,7 @@ public class FetchContext {
     private final LinkedHashSet<AliasWrapper> aliasSet;
     private final List<GenerationField> conditionSourceFields;
     private final ArrayList<CodeBlock> conditionList;
+    private ExistsJoin existsJoin;
     private final String graphPath;
     private final int recCounter;
     private final KeyWrapper resolverKey;
@@ -83,10 +85,10 @@ public class FetchContext {
         this.processedSchema = processedSchema;
 
         if (referenceObjectField.hasNodeID()) {
-             referenceObject = processedSchema.getNodeTypeForNodeIdFieldOrThrow(referenceObjectField);
-         } else {
-             referenceObject = processedSchema.getRecordType(referenceObjectField);
-         }
+            referenceObject = processedSchema.getNodeTypeForNodeIdFieldOrThrow(referenceObjectField);
+        } else {
+            referenceObject = processedSchema.getRecordType(referenceObjectField);
+        }
 
         this.joinSet = joinSet;
         this.aliasSet = aliasSet;
@@ -171,6 +173,30 @@ public class FetchContext {
      */
     public Set<SQLJoinStatement> getJoinSet() {
         return joinSet;
+    }
+
+    /**
+     * Retrieves and removes a one-to-many EXISTS join along with any associated conditions (e.g., from @condition).
+     * The join and conditions were diverted from joinSet/conditionList by resolveNextSequence to avoid row duplication.
+     */
+    public Optional<ExistsJoin> pollExistsJoin() {
+        var result = Optional.ofNullable(existsJoin);
+        existsJoin = null; // Reset after consumption, otherwise the next filter field in the iteration would incorrectly wrap its condition in EXISTS
+        return result;
+    }
+
+    public static class ExistsJoin {
+        private final SQLJoinStatement join;
+        private final List<CodeBlock> conditions = new ArrayList<>();
+
+        ExistsJoin(SQLJoinStatement join) {
+            this.join = join;
+        }
+
+        public SQLJoinStatement join() { return join; }
+        public List<CodeBlock> conditions() { return Collections.unmodifiableList(conditions); }
+
+        void addCondition(CodeBlock condition) { conditions.add(condition); }
     }
 
     /**
@@ -441,7 +467,7 @@ public class FetchContext {
      * Iterate through the provided references and create a new join sequence.
      * @return The new join sequence, with the provided join sequence extended by all the references provided.
      */
-    private JoinListSequence processFieldReferences(JoinListSequence joinSequence, JOOQMapping refTable, List<FieldReference> references, boolean requiresLeftJoin, boolean checkLastRef) {
+    private JoinListSequence processFieldReferences(JoinListSequence joinSequence, JOOQMapping refTable, List<FieldReference> references, boolean isInputReference, boolean checkLastRef) {
         var previousTable = joinSequence.isEmpty() ? getPreviousTable() : joinSequence.getLast().getTable();
         if (getReferenceObjectField().createsDataFetcher() && previousContext != null && checkLastRef) previousTable = previousContext.getPreviousTable();
 
@@ -462,12 +488,12 @@ public class FetchContext {
 
         for (int i = 0; i < references.size(); i++) {
             if (getReferenceObjectField().createsDataFetcher() && previousContext == null && i > 0) break;
-            joinSequence = resolveNextSequence(references.get(i), relations.get(i), joinSequence, requiresLeftJoin);
+            joinSequence = resolveNextSequence(references.get(i), relations.get(i), joinSequence, isInputReference);
         }
         return joinSequence;
     }
 
-    private JoinListSequence resolveNextSequence(FieldReference fRef, TableRelation relation, JoinListSequence joinSequence, boolean requiresLeftJoin) {
+    private JoinListSequence resolveNextSequence(FieldReference fRef, TableRelation relation, JoinListSequence joinSequence, boolean isInputReference) {
         var previous = relation.getFrom();
         var target = relation.getToTable();
 
@@ -504,8 +530,8 @@ public class FetchContext {
                     this.conditionList.add(CodeBlock.of("$L.$L.eq($L.$L)", previousContext.getCurrentJoinSequence().getLast().getMappingName(), fieldName, joinElement.getMappingName(), fieldName));
                 }
             }
-            var join = fRef.createConditionJoinFor(newSequence, targetOrPrevious, requiresLeftJoin);
-            if (!newSequence.isEmpty() || addAllJoinsToJoinSet) joinSet.add(join);
+            var join = fRef.createConditionJoinFor(newSequence, targetOrPrevious, isInputReference);
+            addToJoinSet(join, isInputReference, previous, targetOrPrevious, null, newSequence);
             aliasSet.add(join.getJoinAlias());
             return newSequence.cloneAdd(join.getJoinAlias().getAlias());
         }
@@ -515,15 +541,15 @@ public class FetchContext {
             if (newSequence.isEmpty()) aliasJoinSequence = aliasJoinSequence.cloneAdd(previousContext == null || previousContext.getCurrentJoinSequence().isEmpty() ? previous : previousContext.getCurrentJoinSequence().getLast());
             aliasJoinSequence = aliasJoinSequence.cloneAdd(keyToUse);
 
-            var join = createJoinOnExplicitPathFor(fRef, keyToUse, aliasJoinSequence, target, requiresLeftJoin);
-            if (!newSequence.isEmpty() || addAllJoinsToJoinSet)  joinSet.add(join);
+            var join = createJoinOnExplicitPathFor(fRef, keyToUse, aliasJoinSequence, target, isInputReference);
+            addToJoinSet(join, isInputReference, previous, targetOrPrevious, keyToUse, newSequence);
             aliasSet.add(join.getJoinAlias());
             newSequence = newSequence.cloneAdd(join.getJoinAlias().getAlias());
         }
 
         if (fRef.hasTableCondition() && relation.hasRelation()) {
             var previousTableWithAlias = newSequence.getSecondLast() == null && previousContext != null ? previousContext.getCurrentJoinSequence().render() : newSequence.render(newSequence.getSecondLast());
-            this.conditionList.add(fRef.getTableCondition().formatToString(List.of(previousTableWithAlias, newSequence.render())));
+            addCondition(fRef.getTableCondition().formatToString(List.of(previousTableWithAlias, newSequence.render())));
         }
 
         return newSequence;
@@ -543,6 +569,41 @@ public class FetchContext {
     }
 
     /**
+     * Adds a join to joinSet, or stores it as an EXISTS join if it's a one-to-many filter join.
+     */
+    private void addToJoinSet(SQLJoinStatement join, boolean isInputReference, JOOQMapping from, JOOQMapping to, JOOQMapping key, JoinListSequence currentSequence) {
+        if (!currentSequence.isEmpty() || addAllJoinsToJoinSet) {
+            if (isExistsJoin(isInputReference, from, to, key)) {
+                existsJoin = new ExistsJoin(join);
+            } else {
+                joinSet.add(join);
+            }
+        }
+    }
+
+    /**
+     * Adds a condition to the current EXISTS join if one exists, otherwise to the regular condition list.
+     */
+    private void addCondition(CodeBlock condition) {
+        if (existsJoin != null) {
+            existsJoin.addCondition(condition);
+        } else {
+            conditionList.add(condition);
+        }
+    }
+
+    /**
+     * Checks if a filter LEFT JOIN represents a one-to-many relationship that should use an EXISTS subquery
+     * instead of a regular LEFT JOIN, to avoid row duplication.
+     */
+    private boolean isExistsJoin(boolean isInputReference, JOOQMapping from, JOOQMapping to, JOOQMapping key) {
+        if (isInputReference && from != null && to != null && !from.getMappingName().equalsIgnoreCase(to.getMappingName())) {
+            var relationType = inferRelationType(from.getMappingName(), to.getMappingName(), key);
+            return relationType == TableRelationType.REVERSE_IMPLICIT || relationType == TableRelationType.REVERSE_KEY;
+        }
+        return false;
+    }
+
     /**
      * @return A join statement based on a key reference using path
      */
@@ -558,7 +619,8 @@ public class FetchContext {
                 targetTable,
                 alias,
                 List.of(),
-                isNullable
+                isNullable,
+                keyOverride
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -744,19 +744,24 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
             var isInRecordInput = processedSchema.isInputType(field.getContainerTypeName()) && processedSchema.hasJOOQRecord(field.getContainerTypeName());
             var checksNotEmpty = !checks.isEmpty()
                     && !(isInRecordInput && processedSchema.isNodeIdField(field)); // Skip null checks for nodeId in jOOQ record inputs in queries
+
             var renderedSequence = isInRecordInput ?
                     CodeBlock.of(context.getTargetAlias())
                     :  context.iterateJoinSequenceFor(field).render();
             if (renderedSequence.isEmpty()) {
                 continue;
             }
+            var existsJoin = context.pollExistsJoin();
 
             if (!inputCondition.isOverriddenByAncestors() && !field.hasOverridingCondition()) {
                 if (checksNotEmpty) {
                     conditionBuilder.add(checks + " ? ");
                 }
 
-                conditionBuilder.add(formatCondition(inputCondition, renderedSequence, context));
+                var formattedCondition = existsJoin
+                        .map(it -> wrapConditionInExists(formatCondition(inputCondition, renderedSequence, context), it, context))
+                        .orElseGet(() -> formatCondition(inputCondition, renderedSequence, context));
+                conditionBuilder.add(formattedCondition);
 
                 if (checksNotEmpty) {
                     var fallbackOnFalse = (conditionsShouldFallbackToFalse && inputCondition.isWrappedInList()) || field instanceof VirtualInputField;
@@ -845,6 +850,40 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 field.isIterableWrapped() ? "in" : "eq",
                 name
         );
+    }
+
+    private CodeBlock wrapConditionInExists(CodeBlock filterCondition, FetchContext.ExistsJoin existsJoin, FetchContext context) {
+        var join = existsJoin.join();
+        var aliasName = join.getJoinAlias().getAlias().getMappingName();
+        var rootAlias = context.getCurrentJoinSequence().render();
+
+        var correlation = buildExistsCorrelation(join, aliasName, rootAlias);
+        var innerCondition = Stream.concat(Stream.of(filterCondition), existsJoin.conditions().stream())
+                .reduce((a, b) -> CodeBlock.of("$L.and($L)", a, b))
+                .orElse(filterCondition);
+        return CodeBlock.of("$T.exists($T.selectOne().from($N).where($L.and($L)))",
+                DSL.className, DSL.className, aliasName, correlation, innerCondition);
+    }
+
+    private CodeBlock buildExistsCorrelation(SQLJoinStatement join, String aliasName, CodeBlock rootAlias) {
+        if (join.getKey() != null) {
+            var targetTableName = join.getJoinTargetTable().getTable().getMappingName();
+            return getKeyFields(join.getKey())
+                    .map(fields -> fields.entrySet().stream()
+                            .map(e -> CodeBlock.of("$L.$L.eq($L.$L)",
+                                    aliasName, getJavaFieldName(targetTableName, e.getKey().getName()).orElseThrow(),
+                                    rootAlias, getJavaFieldName(
+                                            getKeyTargetTableJavaName(join.getKey().getMappingName()).orElseThrow(),
+                                            e.getValue().getName()).orElseThrow()))
+                            .reduce((a, b) -> CodeBlock.of("$L.and($L)", a, b))
+                            .orElseThrow())
+                    .orElseThrow(() -> new IllegalStateException("No FK column mapping found for key " + join.getKey().getMappingName()));
+        }
+        // Condition-based joins: reuse the ON condition as correlation
+        return join.getJoinFields().stream()
+                .map(field -> field.toJoinString(join.getJoinSequence(), aliasName))
+                .reduce((a, b) -> CodeBlock.of("$L.and($L)", a, b))
+                .orElseThrow(() -> new IllegalStateException("No join fields found for EXISTS correlation on " + aliasName));
     }
 
     private CodeBlock getCheckedNameWithPath(InputCondition condition) {
@@ -1031,8 +1070,8 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
 
                 var innerFields = isMutationWithJDBCBatching ?
                         getPrimaryKeyForTable(processedSchema.getRecordType(inputField).getTable().getName())
-                                .map(it -> it.getFields().stream().map(col -> new VirtualInputField(col.getName(), inputField.getContainerTypeName())).toList())
-                                .orElse(List.of())
+                        .map(it -> it.getFields().stream().map(col -> new VirtualInputField(col.getName(), inputField.getContainerTypeName())).toList())
+                        .orElse(List.of())
                         : processedSchema.getInputType(inputField).getFields();
 
                 inputBuffer.addAll(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/TableValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/TableValidator.java
@@ -10,6 +10,7 @@ import no.sikt.graphitron.definitions.interfaces.GenerationField;
 import no.sikt.graphitron.definitions.interfaces.GenerationTarget;
 import no.sikt.graphitron.definitions.interfaces.RecordObjectSpecification;
 import no.sikt.graphitron.definitions.mapping.JOOQMapping;
+import no.sikt.graphitron.definitions.mapping.TableRelationType;
 import no.sikt.graphitron.definitions.objects.RecordObjectDefinition;
 import no.sikt.graphql.schema.ProcessedSchema;
 
@@ -22,6 +23,7 @@ import static no.sikt.graphitron.configuration.GeneratorConfig.shouldMakeNodeStr
 import static no.sikt.graphitron.mappings.TableReflection.*;
 import static no.sikt.graphitron.validation.ValidationHandler.addErrorMessage;
 import static no.sikt.graphql.directives.GenerationDirective.NODE_ID;
+import static no.sikt.graphql.directives.GenerationDirective.REFERENCE;
 
 /**
  * Validates table and key existence, reference paths, and required table fields.
@@ -36,6 +38,7 @@ class TableValidator extends AbstractSchemaValidator {
     void validate() {
         validateTablesAndKeys();
         validateRequiredTableFields();
+        validateOneToManyInputReferences();
     }
 
     private void validateTablesAndKeys() {
@@ -279,4 +282,66 @@ class TableValidator extends AbstractSchemaValidator {
             }
         }
     }
+
+    /**
+     * Validates that query arguments and input fields with multistep @reference paths do not contain
+     * one-to-many (REVERSE) joins in non-final steps. Such joins cause row duplication that cannot be resolved
+     * automatically. One-to-many in the final step is allowed, as it is handled by EXISTS subquery generation.
+     */
+    private void validateOneToManyInputReferences() {
+        allFields.forEach(field -> {
+            if (!field.hasNonReservedInputFields()) return;
+            var connectionNode = schema.getObjectOrConnectionNode(field);
+            if (connectionNode == null || !connectionNode.hasTable()) return;
+
+            var rootTable = connectionNode.getTable().getMappingName();
+            field.getNonReservedArguments()
+                    .forEach(arg -> validateNoOneToManyInNonFinalStep(arg, rootTable));
+            field.getNonReservedArguments().stream()
+                    .filter(schema::isInputType)
+                    .flatMap(arg -> schema.getInputType(arg).getFields().stream())
+                    .forEach(inputField -> validateNoOneToManyInNonFinalStep(inputField, rootTable));
+        });
+    }
+
+    /**
+     * Validates that a filter field's @reference path does not contain a one-to-many relationship in a non-final step.
+     * The total number of steps includes an implicit step from @nodeId if it targets a different table than the last
+     * explicit reference.
+     */
+    private void validateNoOneToManyInNonFinalStep(GenerationField field, String rootTable) {
+        var references = field.getFieldReferences();
+        var lastRefTable = resolveReferenceTargetTable(references, rootTable).orElse(rootTable);
+        var nodeType = schema.isNodeIdField(field) ? schema.getNodeTypeForNodeIdField(field).orElse(null) : null;
+        var hasImplicitNodeIdStep = nodeType != null && nodeType.hasTable()
+                && !nodeType.getTable().getMappingName().equals(lastRefTable);
+        var totalSteps = references.size() + (hasImplicitNodeIdStep ? 1 : 0);
+        if (totalSteps < 2) return;
+
+        var currentTable = rootTable;
+        for (int i = 0; i < references.size(); i++) {
+            var ref = references.get(i);
+            String nextTable;
+            if (ref.hasKey()) {
+                nextTable = resolveKeyOtherTable(ref.getKey().getName(), currentTable).orElse(null);
+            } else if (ref.hasTable()) {
+                nextTable = ref.getTable().getMappingName();
+            } else {
+                return;
+            }
+            if (nextTable == null) return;
+            if (i < totalSteps - 1) {
+                var relationType = inferRelationType(currentTable, nextTable, ref.hasKey() ? ref.getKey() : null);
+                if (relationType == TableRelationType.REVERSE_IMPLICIT || relationType == TableRelationType.REVERSE_KEY) {
+                    addErrorMessage(
+                            "Field %s has a multi-step @%s path with a one-to-many relationship " +
+                                    "from \"%s\" to \"%s\" in a non-final step. This is not currently supported on filter inputs because it causes row duplication. " +
+                                    "Use the @condition directive for complex cross-table filtering instead.",
+                            field.formatPath(), REFERENCE.getName(), currentTable, nextTable);
+                }
+            }
+            currentTable = nextTable;
+        }
+    }
+
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ReferenceInputTest.java
@@ -34,11 +34,12 @@ public class ReferenceInputTest extends ReferenceTest {
     }
 
     @Test
-    @DisplayName("Reverse table path")
+    @DisplayName("Reverse table path - uses EXISTS to avoid row duplication from one-to-many LEFT JOIN")
     void tableBackwards() {
         assertGeneratedContentContains(
                 "tableBackwards", Set.of(CUSTOMER_TABLE),
-                ".leftJoin(_a_address_223244161_customer_left"
+                "DSL.exists(DSL.selectOne().from(_a_address_223244161_customer_left).where(",
+                "customer_left.ADDRESS_ID.eq(_a_address.ADDRESS_ID)"
         );
     }
 
@@ -63,11 +64,12 @@ public class ReferenceInputTest extends ReferenceTest {
     }
 
     @Test
-    @DisplayName("Reverse key path")
+    @DisplayName("Reverse key path - uses EXISTS to avoid row duplication from one-to-many LEFT JOIN")
     void keyBackwards() {
         assertGeneratedContentContains(
                 "keyBackwards", Set.of(CUSTOMER_TABLE),
-                ".leftJoin(_a_address_223244161_customer_left"
+                "DSL.exists(DSL.selectOne().from(_a_address_223244161_customer_left).where(",
+                "customer_left.ADDRESS_ID.eq(_a_address.ADDRESS_ID)"
         );
     }
 
@@ -169,6 +171,45 @@ public class ReferenceInputTest extends ReferenceTest {
                 "keyWithMultiplePathsAndNestedSplitQuery",
                 "DSL.select(filmsForLanguage_film())",
                 "private static SelectField<Film> filmsForLanguage_film()"
+        );
+    }
+
+    @Test
+    @DisplayName("Reverse condition path - one-to-many with condition uses EXISTS with condition inside")
+    void conditionBackwards() {
+        assertGeneratedContentContains("conditionBackwards",
+                "DSL.exists(DSL.selectOne().from(_a_address_email_customer_left).where(",
+                ".email(_a_address, _a_address_email_customer_left)"
+        );
+    }
+
+    @Test
+    @DisplayName("Reverse key+condition path - condition appears inside EXISTS")
+    void keyAndConditionBackwards() {
+        assertGeneratedContentContains("keyAndConditionBackwards",
+                "DSL.exists(DSL.selectOne().from(_a_address_223244161_customer_left).where(",
+                ".email(_a_address, _a_address_223244161_customer_left)");
+    }
+
+    @Test
+    @DisplayName("Multi-step path with one-to-many as final step uses EXISTS for the last join")
+    void multiStepEndingInOneToMany() {
+        assertGeneratedContentContains("multiStepEndingInOneToMany", Set.of(CUSTOMER_TABLE),
+                ".leftJoin(_a_customer_2168032777_address_left)",
+                "DSL.exists(DSL.selectOne().from(_a_address_2138977089_staff_left).where("
+        );
+    }
+
+    @Test
+    @DisplayName("Reverse key path with bidirectional FKs uses EXISTS when key disambiguates direction")
+    void reverseWithMultiplePaths() {
+        // Store and Staff have FKs in both directions (STAFF__STAFF_STORE_ID_FKEY and STORE__STORE_MANAGER_STAFF_ID_FKEY).
+        // The explicit key ensures the reverse (one-to-many) direction is detected and wrapped in EXISTS.
+        assertGeneratedContentContains(
+                "reverseWithMultiplePaths",
+                "DSL.exists(DSL.selectOne().from(_a_store_",
+                "_left).where(",
+                ".STORE_ID.eq(_a_store.STORE_ID)"
         );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/NodeIdInputTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/NodeIdInputTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_NODE;
 import static no.sikt.graphitron.common.configuration.SchemaComponent.NODE;
+import static no.sikt.graphitron.common.configuration.SchemaComponent.NODE_QUERY;
 
 @DisplayName("Node directive input validation - Checks run when building the schema for types with node directive")
 public class NodeIdInputTest extends ValidationTest {
@@ -208,5 +209,14 @@ public class NodeIdInputTest extends ValidationTest {
         assertErrorsContain("lookupInputTypeWithImplicitNodeIdReference", Set.of(CUSTOMER_NODE),
                 "Argument 'input' on 'Query.query' has lookupKey directive, but contains reference field(s): 'LookupInput.customerId'. Lookup on references is not currently supported."
         );
+    }
+
+    @Test
+    @DisplayName("@reference with one-to-many join becomes multi-step when combined with @nodeId, and is rejected")
+    void oneToManyWithImplicitNodeIdStep() {
+        assertErrorsContain("oneToManyWithImplicitNodeIdStep", Set.of(NODE),
+                "Field 'storeId' on 'Query.addresses' has a multi-step @reference path with a one-to-many relationship " +
+                        "from \"ADDRESS\" to \"CUSTOMER\" in a non-final step. This is not currently supported on filter inputs because it causes row duplication. " +
+                        "Use the @condition directive for complex cross-table filtering instead.");
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/QueryTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/QueryTest.java
@@ -354,4 +354,13 @@ public class QueryTest extends ValidationTest {
                 )
         );
     }
+
+    @Test
+    @DisplayName("Multi-step reference path with one-to-many on query argument is not supported")
+    void oneToManyMultiStepInputReference() {
+        assertErrorsContain("oneToManyMultiStepInputReference",
+                "Field 'email' on 'Query.cities' has a multi-step @reference path with a one-to-many relationship " +
+                        "from \"CITY\" to \"ADDRESS\" in a non-final step. This is not currently supported on filter inputs because it causes row duplication. " +
+                        "Use the @condition directive for complex cross-table filtering instead.");
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/conditionBackwards/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/conditionBackwards/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(email: String! @reference(path: [{table: "CUSTOMER", condition: {className: "no.sikt.graphitron.codereferences.conditions.ReferenceCustomerCondition", method: "email"}}])): Address
+}
+
+type Address @table {
+  id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/keyAndConditionBackwards/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/keyAndConditionBackwards/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(email: String! @reference(path: [{key: "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY", condition: {className: "no.sikt.graphitron.codereferences.conditions.ReferenceCustomerCondition", method: "email"}}])): Address
+}
+
+type Address @table {
+  id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/multiStepEndingInOneToMany/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/multiStepEndingInOneToMany/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  query(username: String @field(name: "USERNAME") @reference(path: [{key: "CUSTOMER__CUSTOMER_ADDRESS_ID_FKEY"}, {table: "STAFF"}])): CustomerTable
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/reverseWithMultiplePaths/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/references/input/reverseWithMultiplePaths/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(username: String! @field(name: "USERNAME") @reference(path: [{key: "STAFF__STAFF_STORE_ID_FKEY"}])): Store
+}
+
+type Store @table {
+  id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/nodeId/input/oneToManyWithImplicitNodeIdStep/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/nodeId/input/oneToManyWithImplicitNodeIdStep/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+  addresses(storeId: ID @nodeId(typeName: "Store") @reference(path: [{table: "CUSTOMER"}])): [Address]
+}
+
+type Address @table {
+  id: ID!
+}
+
+type Store implements Node @table @node {
+  id: ID! @nodeId
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/query/oneToManyMultiStepInputReference/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/query/oneToManyMultiStepInputReference/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  cities(email: String @field(name: "EMAIL") @reference(path: [{table: "ADDRESS"}, {table: "CUSTOMER"}])): [City]
+}
+
+type City @table {
+  id: ID!
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_one_to_many_filter-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_one_to_many_filter-1.result.approved.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "languagesFilteredByFilm": {
+            "nodes": [
+                {
+                    "id": "TGFuZ3VhZ2U6MQ",
+                    "name": "English             "
+                },
+                {
+                    "id": "TGFuZ3VhZ2U6Mg",
+                    "name": "Italian             "
+                },
+                {
+                    "id": "TGFuZ3VhZ2U6Mw",
+                    "name": "Japanese            "
+                },
+                {
+                    "id": "TGFuZ3VhZ2U6NA",
+                    "name": "Mandarin            "
+                },
+                {
+                    "id": "TGFuZ3VhZ2U6NQ",
+                    "name": "French              "
+                },
+                {
+                    "id": "TGFuZ3VhZ2U6Ng",
+                    "name": "German              "
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_one_to_many_filter-2.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_one_to_many_filter-2.result.approved.json
@@ -1,0 +1,12 @@
+{
+    "data": {
+        "languagesFilteredByFilm": {
+            "nodes": [
+                {
+                    "id": "TGFuZ3VhZ2U6MQ",
+                    "name": "English             "
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_one_to_many_filter.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_one_to_many_filter.graphql
@@ -1,0 +1,8 @@
+query OneToManyFilter($filmId: ID) {
+    languagesFilteredByFilm(filmId: $filmId) {
+        nodes {
+            id
+            name
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_one_to_many_filter.variables.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_one_to_many_filter.variables.json
@@ -1,0 +1,6 @@
+[
+  {},
+  {
+    "filmId": "RmlsbTox"
+  }
+]

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
@@ -28,6 +28,7 @@ type Query {
     filmsWithDescriptionInput(input: [FilmDescriptionInput]): [Film]
 
     languages: [Language] @asConnection
+    languagesFilteredByFilm(filmId: ID @nodeId(typeName: "Film") @reference(path: [{key: "FILM__FILM_LANGUAGE_ID_FKEY"}])): [Language] @asConnection
 
     payments(dateTime: LocalDateTime @field(name: "PAYMENT_DATE"), amount: BigDecimal): [Payment] @asConnection
     paymentsFilteredByInventory(inventoryId: Int @field(name: "inventory_id") @reference(path: [{table: "RENTAL"}])): [Payment] @asConnection


### PR DESCRIPTION
detects when a filter input creates a LEFT JOIN to a table where the FK originates from the target (one-to-many), removes the LEFT JOIN, and wraps the filter condition in DSL.exists