### PR TITLE
fix: resolve Float→BigDecimal and jOOQ EnumType lambda type-inference bugs in formatCondition()

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -554,6 +554,82 @@ public class FormatCodeBlocks {
     }
 
     /**
+     * Variant that handles the case where the jOOQ column type is itself a Java enum implementing
+     * {@link org.jooq.EnumType} (e.g. a PostgreSQL enum column), while the GraphQL enum has no
+     * {@code @enum} directive ({@code hasJavaEnumMapping == false}).
+     *
+     * <p>In this situation the standard converter would emit {@code s -> makeEnumMap(s, List.of("G",…), …)}
+     * where {@code s} is inferred as the jOOQ enum type, but the {@code from} list is {@code List<String>}.
+     * Java's type-inference cannot reconcile the two bounds and the generated code fails to compile.</p>
+     *
+     * <p>The fix uses {@link org.jooq.EnumType#getLiteral()} to convert the jOOQ enum to its string
+     * literal before passing it to {@code makeEnumMap}, and {@link org.jooq.EnumType#lookupLiteral}
+     * for the reverse direction, keeping both sides consistently {@code String}-typed.</p>
+     *
+     * @param columnClass the actual Java type of the jOOQ column field; when it is a {@link org.jooq.EnumType}
+     *                    subclass and the schema enum has no Java mapping, a type-safe converter is generated.
+     * @return Code block containing the enum conversion, or an empty block if inapplicable.
+     */
+    public static CodeBlock toJOOQEnumConverter(String enumType, ProcessedSchema schema, Class<?> columnClass) {
+        if (!schema.isEnum(enumType)) {
+            return CodeBlock.empty();
+        }
+        var enumEntry = schema.getEnum(enumType);
+        if (!enumEntry.hasJavaEnumMapping()
+                && columnClass != null
+                && columnClass.isEnum()
+                && org.jooq.EnumType.class.isAssignableFrom(columnClass)) {
+            return toJOOQEnumConverterForEnumTypeColumn(enumEntry, columnClass);
+        }
+        return toJOOQEnumConverter(enumType, schema);
+    }
+
+    /**
+     * Generates a {@code .convert()} call for a jOOQ column whose Java type is an {@link org.jooq.EnumType}
+     * enum, while the GraphQL enum has no explicit Java mapping ({@code hasJavaEnumMapping == false}).
+     *
+     * <p>Example output:
+     * <pre>{@code
+     * .convert(FilmRating.class,
+     *   (MpaaRating s) -> QueryHelper.makeEnumMap(s.getLiteral(), List.of("G","PG",…), List.of(FilmRating.G,…)),
+     *   (FilmRating s) -> {
+     *     var _s = QueryHelper.makeEnumMap(s, List.of(FilmRating.G,…), List.of("G","PG",…));
+     *     return _s == null ? null : EnumType.lookupLiteral(MpaaRating.class, _s);
+     *   }
+     * )
+     * }</pre>
+     */
+    private static CodeBlock toJOOQEnumConverterForEnumTypeColumn(EnumDefinition enumEntry, Class<?> jooqEnumClass) {
+        var tempVarName = "s";
+        var litVarName = "_s";
+        var dtoClass = enumEntry.getGraphClassName();
+        var jooqClass = ClassName.get(jooqEnumClass);
+
+        // From-lambda: (JooqEnumClass s) -> makeEnumMap(s.getLiteral(), strings, dtos)
+        var fromLambda = CodeBlock.of(
+                "($T $L) -> $L",
+                jooqClass,
+                tempVarName,
+                makeEnumMapBlock(tempVarName + ".getLiteral()", renderEnumMapElements(enumEntry, true))
+        );
+
+        // To-lambda: (DtoClass s) -> { var _s = makeEnumMap(s, dtos, strings); return EnumType.lookupLiteral(JooqClass, _s); }
+        var reverseMapBlock = makeEnumMapBlock(tempVarName, renderEnumMapElements(enumEntry, false));
+        var toLambda = CodeBlock.builder()
+                .add("($T $L) -> {\n", dtoClass, tempVarName)
+                .indent()
+                .add("var $L = $L;\n", litVarName, reverseMapBlock)
+                .add("return $L == null ? null : $T.lookupLiteral($T.class, $L);\n",
+                        litVarName, JOOQ_ENUM_TYPE.className, jooqClass, litVarName)
+                .unindent()
+                .add("}")
+                .build();
+
+        var code = CodeBlock.of("$T.class,\n$L,\n$L", dtoClass, fromLambda, toLambda);
+        return CodeBlock.of(".convert($L)", indentIfMultiline(code));
+    }
+
+    /**
      * @return CodeBlock that converts a SQL array field to a Java List using jOOQ's convertFrom with null-safety.
      */
     public static CodeBlock arrayToListConverter() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -837,11 +837,33 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
             return CodeBlock.join(renderedSequence, generateHasForID(field.getMappingFromFieldOverride(), table, name, field.isIterableWrapped()));
         }
 
+        var hasJooqRecord = processedSchema.hasJOOQRecord(field.getContainerTypeName());
+        var enumConverter = CodeBlock.empty();
+        if (!hasJooqRecord) {
+            var tableName = context.iterateJoinSequenceFor(field).getLast().getTable().getName();
+            var columnType = getFieldType(tableName, field.getUpperCaseName());
+
+            // Bug A: if the jOOQ column is BigDecimal but the GraphQL field produces a different
+            // numeric type (e.g. Float → Double), wrap the value with BigDecimal.valueOf() so
+            // that jOOQ's Field<BigDecimal>.eq(Double) type mismatch does not cause a compile error.
+            // Only applies to single-value conditions (.eq), not lists (.in), which would require
+            // a different stream-based conversion.
+            if (!field.isIterableWrapped()
+                    && columnType.filter(java.math.BigDecimal.class::equals).isPresent()
+                    && !field.getTypeName().equals("BigDecimal")) {
+                name = CodeBlock.of("$T.valueOf($L)", java.math.BigDecimal.class, name);
+            }
+
+            // Bug B: pass the column class so toJOOQEnumConverter can generate explicit lambda
+            // types when the column is a jOOQ EnumType and the schema enum has no @enum directive.
+            enumConverter = toJOOQEnumConverter(field.getTypeName(), processedSchema, columnType.orElse(null));
+        }
+
         return CodeBlock.of(
                 "$L.$N$L.$L($L)",
                 renderedSequence,
                 field.getUpperCaseName(),
-                !processedSchema.hasJOOQRecord(field.getContainerTypeName()) ? toJOOQEnumConverter(field.getTypeName(), processedSchema) : CodeBlock.empty(),
+                enumConverter,
                 field.isIterableWrapped() ? "in" : "eq",
                 name
         );

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/JavaPoetClassName.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/JavaPoetClassName.java
@@ -112,7 +112,8 @@ public enum JavaPoetClassName {
     SELECT_SELECT_STEP(SelectSelectStep.class),
     INT_STREAM(IntStream.class),
     CONNECTION_IMPL(ConnectionImpl.class),
-    FEDERATION_HELPER(no.sikt.graphql.schema.FederationHelper.class);
+    FEDERATION_HELPER(no.sikt.graphql.schema.FederationHelper.class),
+    JOOQ_ENUM_TYPE(org.jooq.EnumType.class);
 
     public final ClassName className;
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/common/configuration/SchemaComponent.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/common/configuration/SchemaComponent.java
@@ -21,6 +21,7 @@ public enum SchemaComponent {
 
     DUMMY_ENUM("enums/DummyEnum"),
     DUMMY_ENUM_CONVERTED("enums/DummyEnumConverted", Set.of(ReferencedEntry.DUMMY_JOOQ_ENUM)),
+    FILM_RATING("enums/FilmRating"),
 
     CUSTOMER("basic/Customer"),
     CUSTOMER_NODE("basic/CustomerNode", NODE),
@@ -29,6 +30,7 @@ public enum SchemaComponent {
     CUSTOMER_QUERY("basic/CustomerQuery"),
     CUSTOMER_NOT_GENERATED("basic/CustomerNotGenerated"),
     CUSTOMER_TABLE("basic/CustomerTable"),
+    FILM_TABLE("basic/FilmTable"),
     CUSTOMER_INPUT_TABLE("basic/CustomerInputTable"),
     CUSTOMER_CONNECTION_ONLY("basic/CustomerConnection", PAGE_INFO),
     CUSTOMER_CONNECTION_WITH_NO_OPTIONALS_ONLY("basic/CustomerConnectionWithNoOptionals", PAGE_INFO),

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ConditionTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/ConditionTest.java
@@ -356,6 +356,26 @@ public class ConditionTest extends GeneratorTest {
     }
 
     @Test
+    @DisplayName("Bug A: Float condition on a BigDecimal column wraps value with BigDecimal.valueOf()")
+    void onFloatConditionBigDecimalColumn() {
+        assertGeneratedContentContains(
+                "onFloatConditionBigDecimalColumn", Set.of(FILM_TABLE),
+                "RENTAL_RATE.eq(BigDecimal.valueOf(_mi_rentalRate))"
+        );
+    }
+
+    @Test
+    @DisplayName("Bug B: Schema-only enum condition on a jOOQ EnumType column uses getLiteral() and lookupLiteral()")
+    void onJooqEnumTypeColumnWithSchemaEnum() {
+        assertGeneratedContentContains(
+                "onJooqEnumTypeColumnWithSchemaEnum", Set.of(FILM_TABLE, FILM_RATING),
+                "RATING.convert(",
+                "s.getLiteral()",
+                "EnumType.lookupLiteral("
+        );
+    }
+
+    @Test
     @DisplayName("Condition on a listed enum parameter")
     void onListedEnum() {
         assertGeneratedContentContains(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/FilmTable.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/basic/FilmTable.graphqls
@@ -1,0 +1,3 @@
+type FilmTable @table(name: "FILM") {
+  id: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/enums/FilmRating.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/components/enums/FilmRating.graphqls
@@ -1,0 +1,6 @@
+# Schema-only enum (no @enum directive) that maps to the jOOQ MpaaRating enum column.
+enum FilmRating {
+    G
+    PG
+    R
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onFloatConditionBigDecimalColumn/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onFloatConditionBigDecimalColumn/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  films(rentalRate: Float @condition): FilmTable
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onJooqEnumTypeColumnWithSchemaEnum/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onJooqEnumTypeColumnWithSchemaEnum/schema.graphqls
@@ -1,0 +1,3 @@
+type Query {
+  films(rating: FilmRating @condition): FilmTable
+}


### PR DESCRIPTION
Bug A: When a GraphQL Float argument maps to a jOOQ Field<BigDecimal> column,
the generated field.eq(doubleValue) call does not compile because jOOQ's
Field<BigDecimal>.eq(Double) overload does not exist. Fix: detect the column
type via TableReflection.getFieldType() at codegen time and wrap scalar values
with BigDecimal.valueOf().

Bug B: When a GraphQL schema enum (no @enum directive) maps to a jOOQ
EnumType column, the generated converter lambdas produce conflicting generic
bounds (T = EnumType subclass from column, T = String from the literal list),
causing javac type-inference failures. Fix: add a new
toJOOQEnumConverterForEnumTypeColumn() code path that emits explicit lambda
parameter types, uses s.getLiteral() for the forward direction, and
EnumType.lookupLiteral() for the reverse direction.

Also adds JOOQ_ENUM_TYPE to JavaPoetClassName, FILM_TABLE/FILM_RATING schema
components, and two new ConditionTest cases to cover both bugs.

https://claude.ai/code/session_01E4Ukg9RNM3oZNGrhY6ALKQ