### PR TITLE
Fixed the argumentPresence structure after hotfix

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
@@ -27,12 +27,17 @@ import static org.apache.commons.lang3.StringUtils.uncapitalize;
 abstract public class AbstractMapperMethodGenerator extends AbstractSchemaMethodGenerator<GenerationField, RecordObjectSpecification<?>> {
     private final GenerationField localField;
     protected final boolean toRecord;
+    private int savedArgsCounter = 0;
 
     public AbstractMapperMethodGenerator(GenerationField localField, ProcessedSchema processedSchema, boolean toRecord) {
         super(processedSchema.getRecordType(localField.getContainerTypeName()), processedSchema);
 
         this.localField = localField;
         this.toRecord = toRecord;
+    }
+
+    protected String nextSavedArgsVar() {
+        return VAR_SAVED_ARGS + savedArgsCounter++;
     }
 
     public GenerationField getLocalField() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
@@ -27,7 +27,7 @@ import static org.apache.commons.lang3.StringUtils.uncapitalize;
 abstract public class AbstractMapperMethodGenerator extends AbstractSchemaMethodGenerator<GenerationField, RecordObjectSpecification<?>> {
     private final GenerationField localField;
     protected final boolean toRecord;
-    private int savedArgsCounter = 0;
+    private int argPresenceCounter = 0;
 
     public AbstractMapperMethodGenerator(GenerationField localField, ProcessedSchema processedSchema, boolean toRecord) {
         super(processedSchema.getRecordType(localField.getContainerTypeName()), processedSchema);
@@ -36,8 +36,8 @@ abstract public class AbstractMapperMethodGenerator extends AbstractSchemaMethod
         this.toRecord = toRecord;
     }
 
-    protected String nextSavedArgsVar() {
-        return VAR_SAVED_ARGS + savedArgsCounter++;
+    protected String nextArgPresenceVar() {
+        return VAR_NEXT_ARGS + argPresenceCounter++;
     }
 
     public GenerationField getLocalField() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/AbstractMapperMethodGenerator.java
@@ -27,17 +27,12 @@ import static org.apache.commons.lang3.StringUtils.uncapitalize;
 abstract public class AbstractMapperMethodGenerator extends AbstractSchemaMethodGenerator<GenerationField, RecordObjectSpecification<?>> {
     private final GenerationField localField;
     protected final boolean toRecord;
-    private int argPresenceCounter = 0;
 
     public AbstractMapperMethodGenerator(GenerationField localField, ProcessedSchema processedSchema, boolean toRecord) {
         super(processedSchema.getRecordType(localField.getContainerTypeName()), processedSchema);
 
         this.localField = localField;
         this.toRecord = toRecord;
-    }
-
-    protected String nextArgPresenceVar() {
-        return VAR_NEXT_ARGS + argPresenceCounter++;
     }
 
     public GenerationField getLocalField() {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -262,24 +262,6 @@ public class FormatCodeBlocks {
     }
 
     /**
-     * @return CodeBlock that checks whether a field is present in the ArgumentPresence tree.
-     * The path may contain slashes for nested non-record wrapper types (e.g. "inner/postalCode"),
-     * in which case intermediate segments are navigated via .child() calls.
-     */
-    @NotNull
-    public static CodeBlock argumentPresenceLookup(String path, boolean atResolver) {
-        var parts = path.split("/");
-        var fieldName = parts[parts.length - 1];
-        CodeBlock base = atResolver
-                ? CodeBlock.of("$L", asMethodCall(VAR_TRANSFORMER, METHOD_ARG_PRESENCE_NAME))
-                : CodeBlock.of("$N", VAR_ARGS);
-        for (int i = 0; i < parts.length - 1; i++) {
-            base = CodeBlock.of("$L.$L($S)", base, METHOD_CHILD, parts[i]);
-        }
-        return CodeBlock.of("$L.$L($S)", base, METHOD_HAS_FIELD, fieldName);
-    }
-
-    /**
      * @return CodeBlock that sets a value through a mapping.
      */
     @NotNull

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/VariableNames.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/VariableNames.java
@@ -19,7 +19,7 @@ public class VariableNames {
             VAR_INDEX_PATH = internalPrefix("indexPath"),
             VAR_PATH_HERE = internalPrefix("pathHere"),
             VAR_ARGS = internalPrefix("args"),
-            VAR_SAVED_ARGS = internalPrefix("savedArgs"),
+            VAR_NEXT_ARGS = internalPrefix("nextArgs"),
             VAR_ENV = internalPrefix("env"),
             VAR_SELECT = internalPrefix("select"),
             VAR_VALIDATION_ERRORS = internalPrefix("validationErrors"),

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/VariableNames.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/VariableNames.java
@@ -19,6 +19,7 @@ public class VariableNames {
             VAR_INDEX_PATH = internalPrefix("indexPath"),
             VAR_PATH_HERE = internalPrefix("pathHere"),
             VAR_ARGS = internalPrefix("args"),
+            VAR_SAVED_ARGS = internalPrefix("savedArgs"),
             VAR_ENV = internalPrefix("env"),
             VAR_SELECT = internalPrefix("select"),
             VAR_VALIDATION_ERRORS = internalPrefix("validationErrors"),

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
@@ -87,12 +87,9 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                     innerCode.add(innerContext.getRecordSetMappingBlock());
                 } else if (toRecord) {
                     var nextArgsVar = nextArgPresenceVar();
-                    innerCode.add(
-                            CodeBlock.builder()
-                                    .declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName())
-                                    .add(iterateRecords(innerContext, nextArgsVar))
-                                    .build()
-                    );
+                    innerCode.
+                            declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName()).
+                            add(iterateRecords(innerContext, nextArgsVar));
                 } else {
                     innerCode.add(iterateRecords(innerContext));
                 }
@@ -104,18 +101,18 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                 var notAlreadyDefined = innerContext.variableNotAlreadyDeclared();
                 var shouldDeclareVariable = notAlreadyDefined || innerContext.getTarget().createsDataFetcher();
                 var nullBlock = CodeBlock.ofIf(shouldDeclareVariable, "$N != null", varName);
-                var isNonRecordWrapper = innerContext.targetIsType() && !innerContext.hasRecordReference() && !innerContext.getTarget().createsDataFetcher();
+                var isWrapperWithoutRecord = innerContext.targetIsType() && !innerContext.hasRecordReference() && !innerContext.getTarget().createsDataFetcher();
 
-                var presenceCheck = isNonRecordWrapper && toRecord
+                var presenceCheck = isWrapperWithoutRecord && toRecord
                         ? CodeBlock.empty()
                         : toRecord
                             ? CodeBlock.of("$L.hasField($S)", argumentSetName, innerField.getName())
                             : selectionSetLookup(innerContext.getPath(), false, false);
-                var condition = nullBlock.isEmpty()
+                var condition = !shouldDeclareVariable
                         ? presenceCheck
                         : presenceCheck.isEmpty()
                             ? nullBlock
-                            : CodeBlock.of("$L && $L", nullBlock, presenceCheck);
+                            : CodeBlock.join(" && ", nullBlock, presenceCheck);
                 fieldCode
                         .declareIf(shouldDeclareVariable, varName, innerContext.getSourceGetCallBlock())
                         .beginControlFlow("if ($L)", condition)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
@@ -6,7 +6,6 @@ import no.sikt.graphitron.definitions.mapping.JOOQMapping;
 import no.sikt.graphitron.definitions.mapping.MethodMapping;
 import no.sikt.graphitron.definitions.objects.ObjectDefinition;
 import no.sikt.graphitron.generators.abstractions.AbstractMapperMethodGenerator;
-import no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks;
 import no.sikt.graphitron.generators.context.MapperContext;
 import no.sikt.graphitron.javapoet.CodeBlock;
 import no.sikt.graphitron.javapoet.MethodSpec;
@@ -38,12 +37,17 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
         return getMapperSpecBuilder(target).build();
     }
 
+
+    @Override
+    protected CodeBlock iterateRecords(MapperContext context){
+        return iterateRecords(context, VAR_ARGS);
+    }
+
     /**
      * @return Code for setting the record data from input types.
      */
     @NotNull
-    @Override
-    protected CodeBlock iterateRecords(MapperContext context) {
+    protected CodeBlock iterateRecords(MapperContext context, String argumentSetName) {
         if (context.isIterable() && !context.hasRecordReference()) {
             return CodeBlock.empty(); // Can not allow this, because input type may contain multiple fields. These can not be mapped to a single field in any reasonable way.
         }
@@ -82,13 +86,11 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                 } else if (innerContext.hasRecordReference()) {
                     innerCode.add(innerContext.getRecordSetMappingBlock());
                 } else if (toRecord) {
-                    var savedArgsVar = nextSavedArgsVar();
+                    var nextArgsVar = nextArgPresenceVar();
                     innerCode.add(
                             CodeBlock.builder()
-                                    .declare(savedArgsVar, "$N", VAR_ARGS)
-                                    .addStatement("$1N = $1N.child($2S)", VAR_ARGS, innerField.getName())
-                                    .add(iterateRecords(innerContext))
-                                    .addStatement("$N = $N", VAR_ARGS, savedArgsVar)
+                                    .declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName())
+                                    .add(iterateRecords(innerContext, nextArgsVar))
                                     .build()
                     );
                 } else {
@@ -107,7 +109,7 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                 var presenceCheck = isNonRecordWrapper && toRecord
                         ? CodeBlock.empty()
                         : toRecord
-                            ? CodeBlock.of("$L.hasField($S)", VAR_ARGS, innerField.getName())
+                            ? CodeBlock.of("$L.hasField($S)", argumentSetName, innerField.getName())
                             : selectionSetLookup(innerContext.getPath(), false, false);
                 var condition = nullBlock.isEmpty()
                         ? presenceCheck

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
@@ -81,6 +81,16 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                     innerCode.add(innerContext.getFieldSetMappingBlock());
                 } else if (innerContext.hasRecordReference()) {
                     innerCode.add(innerContext.getRecordSetMappingBlock());
+                } else if (toRecord) {
+                    var savedArgsVar = nextSavedArgsVar();
+                    innerCode.add(
+                            CodeBlock.builder()
+                                    .declare(savedArgsVar, "$N", VAR_ARGS)
+                                    .addStatement("$1N = $1N.child($2S)", VAR_ARGS, innerField.getName())
+                                    .add(iterateRecords(innerContext))
+                                    .addStatement("$N = $N", VAR_ARGS, savedArgsVar)
+                                    .build()
+                    );
                 } else {
                     innerCode.add(iterateRecords(innerContext));
                 }
@@ -91,10 +101,22 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
             if (!innerCode.isEmpty()) {
                 var notAlreadyDefined = innerContext.variableNotAlreadyDeclared();
                 var shouldDeclareVariable = notAlreadyDefined || innerContext.getTarget().createsDataFetcher();
-                var nullBlock = CodeBlock.ofIf(shouldDeclareVariable, "$N != null && ", varName);
+                var nullBlock = CodeBlock.ofIf(shouldDeclareVariable, "$N != null", varName);
+                var isNonRecordWrapper = innerContext.targetIsType() && !innerContext.hasRecordReference() && !innerContext.getTarget().createsDataFetcher();
+
+                var presenceCheck = isNonRecordWrapper && toRecord
+                        ? CodeBlock.empty()
+                        : toRecord
+                            ? CodeBlock.of("$L.hasField($S)", VAR_ARGS, innerField.getName())
+                            : selectionSetLookup(innerContext.getPath(), false, false);
+                var condition = nullBlock.isEmpty()
+                        ? presenceCheck
+                        : presenceCheck.isEmpty()
+                            ? nullBlock
+                            : CodeBlock.of("$L && $L", nullBlock, presenceCheck);
                 fieldCode
                         .declareIf(shouldDeclareVariable, varName, innerContext.getSourceGetCallBlock())
-                        .beginControlFlow("if ($L$L)", nullBlock, toRecord ? argumentPresenceLookup(innerContext.getPath(), false) : selectionSetLookup(innerContext.getPath(), false, false))
+                        .beginControlFlow("if ($L)", condition)
                         .add(innerCode.build())
                         .endControlFlow()
                         .add("\n");
@@ -205,9 +227,8 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
             var listVarName = mapperNodeInputPrefix(field.getName());
             listVarNames.add(listVarName);
             var getterMapping = new MethodMapping(field.getName());
-            var fieldPath = context.getPath().isEmpty() ? field.getName() : context.getPath() + "/" + field.getName();
             code.declare(listVarName,
-                    "$L ? $L : null", FormatCodeBlocks.argumentPresenceLookup(fieldPath, false),
+                    "$L.hasField($S) ? $L : null", VAR_ARGS, field.getName(),
                     asMethodCall(inputVar, getterMapping.asGet()));
         }
 
@@ -273,9 +294,8 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
         var inputVar = namedIteratorPrefix(sourceName);
         var getterMapping = new MethodMapping(field.getName());
 
-        var fieldPath = context.getPath().isEmpty() ? field.getName() : context.getPath() + "/" + field.getName();
         return CodeBlock.builder()
-                .beginControlFlow("if ($L)", FormatCodeBlocks.argumentPresenceLookup(fieldPath, false))
+                .beginControlFlow("if ($N.hasField($S))", VAR_ARGS, field.getName())
                 .declare(VAR_NODE_ID_VALUE, asMethodCall(inputVar, getterMapping.asGet()))
                 .add(
                         wrapNotNull(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/JavaRecordMapperMethodGenerator.java
@@ -40,14 +40,15 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
 
     @Override
     protected CodeBlock iterateRecords(MapperContext context){
-        return iterateRecords(context, VAR_ARGS);
+        return iterateRecords(context, 0);
     }
 
     /**
      * @return Code for setting the record data from input types.
      */
     @NotNull
-    protected CodeBlock iterateRecords(MapperContext context, String argumentSetName) {
+    protected CodeBlock iterateRecords(MapperContext context, int argDepth) {
+        var argumentSetName = argDepth == 0 ? VAR_ARGS : VAR_NEXT_ARGS + (argDepth - 1);
         if (context.isIterable() && !context.hasRecordReference()) {
             return CodeBlock.empty(); // Can not allow this, because input type may contain multiple fields. These can not be mapped to a single field in any reasonable way.
         }
@@ -86,10 +87,9 @@ public class JavaRecordMapperMethodGenerator extends AbstractMapperMethodGenerat
                 } else if (innerContext.hasRecordReference()) {
                     innerCode.add(innerContext.getRecordSetMappingBlock());
                 } else if (toRecord) {
-                    var nextArgsVar = nextArgPresenceVar();
-                    innerCode.
-                            declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName()).
-                            add(iterateRecords(innerContext, nextArgsVar));
+                    innerCode
+                            .declare(VAR_NEXT_ARGS + argDepth, "$N.child($S)", argumentSetName, innerField.getName())
+                            .add(iterateRecords(innerContext, argDepth + 1));
                 } else {
                     innerCode.add(iterateRecords(innerContext));
                 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.*;
+import static no.sikt.graphitron.generators.codebuilding.VariableNames.VAR_ARGS;
+
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.inputPrefix;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.outputPrefix;
 import static no.sikt.graphql.naming.GraphQLReservedName.ERROR_FIELD;
@@ -68,7 +70,19 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
             } else if (!previousHadSource) {
                 innerCode.add(innerContext.getRecordSetMappingBlock());
             } else if (!innerField.createsDataFetcher() && !innerContext.hasTable()) {
-                innerCode.add(iterateRecords(innerContext));
+                if(toRecord) {
+                    var savedArgsVar = nextSavedArgsVar();
+                    innerCode.add(
+                            CodeBlock.builder()
+                                    .declare(savedArgsVar, "$N", VAR_ARGS)
+                                    .addStatement("$1N = $1N.child($2S)", VAR_ARGS, innerField.getName())
+                                    .add(iterateRecords(innerContext))
+                                    .addStatement("$N = $N", VAR_ARGS, savedArgsVar)
+                                    .build()
+                    );
+                } else {
+                    innerCode.add(iterateRecords(innerContext));
+                }
             }
 
             if (!innerCode.isEmpty()) {
@@ -87,7 +101,7 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
                     fieldCode.add(
                             CodeBlock
                                     .builder()
-                                    .beginControlFlow("if ($L)", toRecord ? argumentPresenceLookup(innerContext.getPath(), false) : selectionSetLookup(innerContext.getPath(), false, false))
+                                    .beginControlFlow("if ($L)", toRecord ?  CodeBlock.of("$L.hasField($S)", VAR_ARGS, innerField.getName()) : selectionSetLookup(innerContext.getPath(), false, false))
                                     .addIf(isType && previousHadSource, declareBlock)
                                     .add(innerCode.build())
                                     .addIf(isType && previousHadSource && !innerField.createsDataFetcher(), () -> innerContext.getSetMappingBlock(outputPrefix(varName)))

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
@@ -27,12 +27,16 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
         return getMapperSpecBuilder(target).build();
     }
 
+
+
+    protected CodeBlock iterateRecords(MapperContext context) {
+        return iterateRecords(context, VAR_ARGS);
+    }
     /**
      * @return Code for setting the record data of previously defined records.
      */
     @NotNull
-    @Override
-    protected CodeBlock iterateRecords(MapperContext context) {
+    protected CodeBlock iterateRecords(MapperContext context, String argumentSetName) {
         if (context.isIterable() && !context.hasTable() && context.hasSourceName()) {
             return CodeBlock.empty();
         }
@@ -71,13 +75,11 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
                 innerCode.add(innerContext.getRecordSetMappingBlock());
             } else if (!innerField.createsDataFetcher() && !innerContext.hasTable()) {
                 if(toRecord) {
-                    var savedArgsVar = nextSavedArgsVar();
+                    var nextArgsVar = nextArgPresenceVar();
                     innerCode.add(
                             CodeBlock.builder()
-                                    .declare(savedArgsVar, "$N", VAR_ARGS)
-                                    .addStatement("$1N = $1N.child($2S)", VAR_ARGS, innerField.getName())
-                                    .add(iterateRecords(innerContext))
-                                    .addStatement("$N = $N", VAR_ARGS, savedArgsVar)
+                                    .declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName())
+                                    .add(iterateRecords(innerContext, nextArgsVar))
                                     .build()
                     );
                 } else {
@@ -101,7 +103,7 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
                     fieldCode.add(
                             CodeBlock
                                     .builder()
-                                    .beginControlFlow("if ($L)", toRecord ?  CodeBlock.of("$L.hasField($S)", VAR_ARGS, innerField.getName()) : selectionSetLookup(innerContext.getPath(), false, false))
+                                    .beginControlFlow("if ($L)", toRecord ?  CodeBlock.of("$L.hasField($S)", argumentSetName, innerField.getName()) : selectionSetLookup(innerContext.getPath(), false, false))
                                     .addIf(isType && previousHadSource, declareBlock)
                                     .add(innerCode.build())
                                     .addIf(isType && previousHadSource && !innerField.createsDataFetcher(), () -> innerContext.getSetMappingBlock(outputPrefix(varName)))

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/mapping/RecordMapperMethodGenerator.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 
 import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.*;
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.VAR_ARGS;
+import static no.sikt.graphitron.generators.codebuilding.VariableNames.VAR_NEXT_ARGS;
 
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.inputPrefix;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.outputPrefix;
@@ -30,13 +31,14 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
 
 
     protected CodeBlock iterateRecords(MapperContext context) {
-        return iterateRecords(context, VAR_ARGS);
+        return iterateRecords(context, 0);
     }
     /**
      * @return Code for setting the record data of previously defined records.
      */
     @NotNull
-    protected CodeBlock iterateRecords(MapperContext context, String argumentSetName) {
+    protected CodeBlock iterateRecords(MapperContext context, int argDepth) {
+        var argumentSetName = argDepth == 0 ? VAR_ARGS : VAR_NEXT_ARGS + (argDepth - 1);
         if (context.isIterable() && !context.hasTable() && context.hasSourceName()) {
             return CodeBlock.empty();
         }
@@ -75,13 +77,9 @@ public class RecordMapperMethodGenerator extends AbstractMapperMethodGenerator {
                 innerCode.add(innerContext.getRecordSetMappingBlock());
             } else if (!innerField.createsDataFetcher() && !innerContext.hasTable()) {
                 if(toRecord) {
-                    var nextArgsVar = nextArgPresenceVar();
-                    innerCode.add(
-                            CodeBlock.builder()
-                                    .declare(nextArgsVar, "$N.child($S)", argumentSetName, innerField.getName())
-                                    .add(iterateRecords(innerContext, nextArgsVar))
-                                    .build()
-                    );
+                    innerCode
+                            .declare(VAR_NEXT_ARGS + argDepth, "$N.child($S)", argumentSetName, innerField.getName())
+                            .add(iterateRecords(innerContext, argDepth + 1));
                 } else {
                     innerCode.add(iterateRecords(innerContext));
                 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
@@ -63,11 +63,20 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void containingNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingNonRecordWrapper",
-                "inner = _nit_address.getInner();",
-                        "if (_mi_inner != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
-                        "if (_iv_nextArgs0.hasField(\"postalCode\")) {",
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());"
+                """
+                        var _nit_address = _mi_address.get(_niit_address);
+                        var _iv_args = _iv_argPresence.itemAt(_niit_address);
+                        if (_nit_address == null) continue;
+                        var _mo_mapperAddressJavaRecord = new MapperAddressJavaRecord();
+                        var _mi_inner = _nit_address.getInner();
+                        if (_mi_inner != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner");
+                            if (_iv_nextArgs0.hasField("postalCode")) {
+                                _mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());
+                            }
+                        }
+                        _mlo_mapperAddressJavaRecord.add(_mo_mapperAddressJavaRecord);
+                        """
         );
     }
 
@@ -76,13 +85,20 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void containingDoubleNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingDoubleNonRecordWrapper",
-                        "if (_mi_inner0 != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner0\");",
-                        "var _mi_inner1 = _mi_inner0.getInner1();",
-                        "if (_mi_inner1 != null) {",
-                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner1\");",
-                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());"
+                """
+                        var _mi_inner0 = _nit_address.getInner0();
+                        if (_mi_inner0 != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner0");
+                            var _mi_inner1 = _mi_inner0.getInner1();
+                            if (_mi_inner1 != null) {
+                                var _iv_nextArgs1 = _iv_nextArgs0.child("inner1");
+                                if (_iv_nextArgs1.hasField("postalCode")) {
+                                    _mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());
+                                }
+                            }
+                        }
+                        _mlo_mapperAddressJavaRecord.add(_mo_mapperAddressJavaRecord);
+                        """
         );
     }
 
@@ -92,14 +108,14 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void nestingWithDuplicateFieldName() {
         assertGeneratedContentContains(
                 "nestingWithDuplicateFieldName",
-                "inner = itAddress.getInner();",
-                        "if (inner != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
-                        "var inner = inner.getInner();",
-                        "if (inner != null) {",
-                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner\");",
-                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
-                        "mapperAddressJavaRecord.setPostalCode(inner.getPostalCode())"
+                """
+                        var _mi_inner = _nit_address.getInner();
+                        if (_mi_inner != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner");
+                            var _mi_inner = _mi_inner.getInner();
+                            if (_mi_inner != null) {
+                                var _iv_nextArgs1 = _iv_nextArgs0.child("inner");
+                        """
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
@@ -63,10 +63,13 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void containingNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingNonRecordWrapper",
-                "inner = _nit_address.getInner();" +
-                        "if (_mi_inner != null && _iv_args.hasField(\"inner\")) {" +
-                        "if (_iv_args.child(\"inner\").hasField(\"postalCode\")) {" +
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());"
+                "inner = _nit_address.getInner();",
+                        "if (_mi_inner != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 
@@ -75,11 +78,17 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void containingDoubleNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingDoubleNonRecordWrapper",
-                        "if (_mi_inner0 != null && _iv_args.hasField(\"inner0\")) {" +
-                        "var _mi_inner1 = _mi_inner0.getInner1();" +
-                        "if (_mi_inner1 != null && _iv_args.child(\"inner0\").hasField(\"inner1\")) {" +
-                        "if (_iv_args.child(\"inner0\").child(\"inner1\").hasField(\"postalCode\")) {" +
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());"
+                        "if (_mi_inner0 != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner0\");",
+                        "var _mi_inner1 = _mi_inner0.getInner1();",
+                        "if (_mi_inner1 != null) {",
+                        "var _iv_savedArgs1 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner1\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());",
+                        "_iv_args = _iv_savedArgs1;",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 
@@ -89,12 +98,18 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
     void nestingWithDuplicateFieldName() {
         assertGeneratedContentContains(
                 "nestingWithDuplicateFieldName",
-                "inner = itAddress.getInner();" +
-                        "if (inner != null && _iv_args.hasField(\"inner\")) {" +
-                        "var inner = inner.getInner();" +
-                        "if (inner != null && _iv_args.child(\"inner\").hasField(\"inner\")) {" +
-                        "if (_iv_args.child(\"inner\").child(\"inner\").hasField(\"postalCode\")) {" +
-                        "mapperAddressJavaRecord.setPostalCode(inner.getPostalCode()"
+                "inner = itAddress.getInner();",
+                        "if (inner != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "var inner = inner.getInner();",
+                        "if (inner != null) {",
+                        "var _iv_savedArgs1 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "mapperAddressJavaRecord.setPostalCode(inner.getPostalCode())",
+                        "_iv_args = _iv_savedArgs1;",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/javarecordmappers/JavaMapperGeneratorToRecordTest.java
@@ -65,11 +65,9 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
                 "containingNonRecordWrapper",
                 "inner = _nit_address.getInner();",
                         "if (_mi_inner != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
+                        "if (_iv_nextArgs0.hasField(\"postalCode\")) {",
+                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner.getPostalCode());"
         );
     }
 
@@ -79,16 +77,12 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "containingDoubleNonRecordWrapper",
                         "if (_mi_inner0 != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner0\");",
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner0\");",
                         "var _mi_inner1 = _mi_inner0.getInner1();",
                         "if (_mi_inner1 != null) {",
-                        "var _iv_savedArgs1 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner1\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());",
-                        "_iv_args = _iv_savedArgs1;",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner1\");",
+                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
+                        "_mo_mapperAddressJavaRecord.setPostalCode(_mi_inner1.getPostalCode());"
         );
     }
 
@@ -100,16 +94,12 @@ public class JavaMapperGeneratorToRecordTest extends GeneratorTest {
                 "nestingWithDuplicateFieldName",
                 "inner = itAddress.getInner();",
                         "if (inner != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
                         "var inner = inner.getInner();",
                         "if (inner != null) {",
-                        "var _iv_savedArgs1 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "mapperAddressJavaRecord.setPostalCode(inner.getPostalCode())",
-                        "_iv_args = _iv_savedArgs1;",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner\");",
+                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
+                        "mapperAddressJavaRecord.setPostalCode(inner.getPostalCode())"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
@@ -67,11 +67,9 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
         assertGeneratedContentContains(
                 "containingNonRecordWrapper",
                 "if (_mi_address_inner != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
+                        "if (_iv_nextArgs0.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());"
         );
     }
 
@@ -82,16 +80,12 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
                 "containingDoubleNonRecordWrapper",
                 "_mi_address_inner0 = _nit_address.getInner0();",
                         "if (_mi_address_inner0 != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner0\");",
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner0\");",
                         "var _mi_wrapper_inner1 = _mi_address_inner0.getInner1();",
                         "if (_mi_wrapper_inner1 != null) {",
-                        "var _iv_savedArgs1 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner1\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner1.getPostalCode());",
-                        "_iv_args = _iv_savedArgs1;",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner1\");",
+                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner1.getPostalCode());"
         );
     }
 
@@ -102,16 +96,12 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
                 "nestingWithDuplicateFieldName",
                 "_mi_address_inner = _nit_address.getInner();",
                         "if (_mi_address_inner != null) {",
-                        "var _iv_savedArgs0 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
+                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
                         "var _mi_wrapper_inner = _mi_address_inner.getInner();",
                         "if (_mi_wrapper_inner != null) {",
-                        "var _iv_savedArgs1 = _iv_args;",
-                        "_iv_args = _iv_args.child(\"inner\");",
-                        "if (_iv_args.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner.getPostalCode())",
-                        "_iv_args = _iv_savedArgs1;",
-                        "_iv_args = _iv_savedArgs0;"
+                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner\");",
+                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner.getPostalCode())"
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
@@ -66,10 +66,15 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void containingNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingNonRecordWrapper",
-                "if (_mi_address_inner != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
-                        "if (_iv_nextArgs0.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());"
+                """
+                        if (_mi_address_inner != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner");
+                            if (_iv_nextArgs0.hasField("postalCode")) {
+                                _mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());
+                            }
+                        }
+                        _mlo_addressRecord.add(_mo_addressRecord);
+                        """
         );
     }
 
@@ -78,14 +83,15 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void containingDoubleNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingDoubleNonRecordWrapper",
-                "_mi_address_inner0 = _nit_address.getInner0();",
-                        "if (_mi_address_inner0 != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner0\");",
-                        "var _mi_wrapper_inner1 = _mi_address_inner0.getInner1();",
-                        "if (_mi_wrapper_inner1 != null) {",
-                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner1\");",
-                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner1.getPostalCode());"
+                """
+                        var _mi_address_inner0 = _nit_address.getInner0();
+                        if (_mi_address_inner0 != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner0");
+                            var _mi_wrapper_inner1 = _mi_address_inner0.getInner1();
+                            if (_mi_wrapper_inner1 != null) {
+                                var _iv_nextArgs1 = _iv_nextArgs0.child("inner1");
+                        """
+
         );
     }
 
@@ -94,14 +100,12 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void nestingWithDuplicateFieldName() {
         assertGeneratedContentContains(
                 "nestingWithDuplicateFieldName",
-                "_mi_address_inner = _nit_address.getInner();",
-                        "if (_mi_address_inner != null) {",
-                        "var _iv_nextArgs0 = _iv_args.child(\"inner\");",
-                        "var _mi_wrapper_inner = _mi_address_inner.getInner();",
-                        "if (_mi_wrapper_inner != null) {",
-                        "var _iv_nextArgs1 = _iv_nextArgs0.child(\"inner\");",
-                        "if (_iv_nextArgs1.hasField(\"postalCode\")) {",
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner.getPostalCode())"
+                """
+                        var _mi_address_inner = _nit_address.getInner();
+                        if (_mi_address_inner != null) {
+                            var _iv_nextArgs0 = _iv_args.child("inner");
+                            var _mi_wrapper_inner = _mi_address_inner.getInner();
+                        """
         );
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooqrecordmappers/MapperGeneratorToRecordTest.java
@@ -66,10 +66,12 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void containingNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingNonRecordWrapper",
-                "if (_mi_address_inner != null) {" +
-                        "if (_iv_args.child(\"inner\").hasField(\"postalCode\")) {" +
-                        "_mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());}}" +
-                        "_mlo_addressRecord.add(_mo_addressRecord)"
+                "if (_mi_address_inner != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_address_inner.getPostalCode());",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 
@@ -78,12 +80,18 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void containingDoubleNonRecordWrapper() {
         assertGeneratedContentContains(
                 "containingDoubleNonRecordWrapper",
-                "address_inner0 = _nit_address.getInner0();" +
-                        "if (_mi_address_inner0 != null) {" +
-                        "var _mi_wrapper_inner1 = _mi_address_inner0.getInner1();" +
-                        "if (_mi_wrapper_inner1 != null) {" +
-                        "if (_iv_args.child(\"inner0\").child(\"inner1\").hasField(\"postalCode\")) {" +
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner1.getPostalCode());"
+                "_mi_address_inner0 = _nit_address.getInner0();",
+                        "if (_mi_address_inner0 != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner0\");",
+                        "var _mi_wrapper_inner1 = _mi_address_inner0.getInner1();",
+                        "if (_mi_wrapper_inner1 != null) {",
+                        "var _iv_savedArgs1 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner1\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner1.getPostalCode());",
+                        "_iv_args = _iv_savedArgs1;",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 
@@ -92,12 +100,18 @@ public class MapperGeneratorToRecordTest extends GeneratorTest {
     void nestingWithDuplicateFieldName() {
         assertGeneratedContentContains(
                 "nestingWithDuplicateFieldName",
-                "address_inner = _nit_address.getInner();" +
-                        "if (_mi_address_inner != null) {" +
-                        "var _mi_wrapper_inner = _mi_address_inner.getInner();" +
-                        "if (_mi_wrapper_inner != null) {" +
-                        "if (_iv_args.child(\"inner\").child(\"inner\").hasField(\"postalCode\")) {" +
-                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner.getPostalCode()"
+                "_mi_address_inner = _nit_address.getInner();",
+                        "if (_mi_address_inner != null) {",
+                        "var _iv_savedArgs0 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "var _mi_wrapper_inner = _mi_address_inner.getInner();",
+                        "if (_mi_wrapper_inner != null) {",
+                        "var _iv_savedArgs1 = _iv_args;",
+                        "_iv_args = _iv_args.child(\"inner\");",
+                        "if (_iv_args.hasField(\"postalCode\")) {",
+                        "_mo_addressRecord.setPostalCode(_mi_wrapper_inner.getPostalCode())",
+                        "_iv_args = _iv_savedArgs1;",
+                        "_iv_args = _iv_savedArgs0;"
         );
     }
 

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-1.result.approved.json
@@ -1,0 +1,14 @@
+{
+    "data": {
+        "testingNestedInputType": [
+            {
+                "id": "Q3VzdG9tZXI6MTAw",
+                "email": "updated@example.com",
+                "name": {
+                    "firstName": "UpdatedFirst",
+                    "lastName": "UpdatedLast"
+                }
+            }
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-2.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-2.result.approved.json
@@ -1,0 +1,14 @@
+{
+    "data": {
+        "testingNestedInputType": [
+            {
+                "id": "Q3VzdG9tZXI6MTAx",
+                "email": "PEGGY.MYERS@sakilacustomer.org",
+                "name": {
+                    "firstName": "OnlyFirst",
+                    "lastName": "OnlyLast"
+                }
+            }
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-3.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input-3.result.approved.json
@@ -1,0 +1,14 @@
+{
+    "data": {
+        "testingNestedInputType": [
+            {
+                "id": "Q3VzdG9tZXI6MTAy",
+                "email": "CRYSTAL.FORD@sakilacustomer.org",
+                "name": {
+                    "firstName": "JustFirst",
+                    "lastName": "FORD"
+                }
+            }
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input_listed-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_nested_input_listed-1.result.approved.json
@@ -1,0 +1,30 @@
+{
+    "data": {
+        "testingListedNestedInputType": [
+            {
+                "id": "Q3VzdG9tZXI6MTAw",
+                "email": "updated@example.com",
+                "name": {
+                    "firstName": "UpdatedFirst",
+                    "lastName": "UpdatedLast"
+                }
+            },
+            {
+                "id": "Q3VzdG9tZXI6MTAx",
+                "email": "PEGGY.MYERS@sakilacustomer.org",
+                "name": {
+                    "firstName": "OnlyFirst",
+                    "lastName": "OnlyLast"
+                }
+            },
+            {
+                "id": "Q3VzdG9tZXI6MTAy",
+                "email": "CRYSTAL.FORD@sakilacustomer.org",
+                "name": {
+                    "firstName": "JustFirst",
+                    "lastName": "FORD"
+                }
+            }
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input.graphql
@@ -1,0 +1,11 @@
+# Verify per-item argument presence with deeply nested non-record wrapper inputs (unlisted)
+mutation TestingNestedInputType($in: NestedInputType!) {
+    testingNestedInputType(in: $in) {
+        id
+        email
+        name {
+            firstName
+            lastName
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input.variables.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input.variables.json
@@ -1,0 +1,35 @@
+[
+  {
+    "in": {
+      "id": "Q3VzdG9tZXI6MTAw",
+      "level0": {
+        "first_name": "UpdatedFirst",
+        "level1": {
+          "last_name": "UpdatedLast",
+          "level2": {
+            "email": "updated@example.com"
+          }
+        }
+      }
+    }
+  },
+  {
+    "in": {
+      "id": "Q3VzdG9tZXI6MTAx",
+      "level0": {
+        "first_name": "OnlyFirst",
+        "level1": {
+          "last_name": "OnlyLast"
+        }
+      }
+    }
+  },
+  {
+    "in": {
+      "id": "Q3VzdG9tZXI6MTAy",
+      "level0": {
+        "first_name": "JustFirst"
+      }
+    }
+  }
+]

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input_listed.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input_listed.graphql
@@ -1,0 +1,11 @@
+# Verify per-item argument presence with deeply nested non-record wrapper inputs (listed)
+mutation TestingListedNestedInputType($in: [NestedInputType!]!) {
+    testingListedNestedInputType(in: $in) {
+        id
+        email
+        name {
+            firstName
+            lastName
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input_listed.variables.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_nested_input_listed.variables.json
@@ -1,0 +1,33 @@
+[
+  {
+    "in": [
+      {
+        "id": "Q3VzdG9tZXI6MTAw",
+        "level0": {
+          "first_name": "UpdatedFirst",
+          "level1": {
+            "last_name": "UpdatedLast",
+            "level2": {
+              "email": "updated@example.com"
+            }
+          }
+        }
+      },
+      {
+        "id": "Q3VzdG9tZXI6MTAx",
+        "level0": {
+          "first_name": "OnlyFirst",
+          "level1": {
+            "last_name": "OnlyLast"
+          }
+        }
+      },
+      {
+        "id": "Q3VzdG9tZXI6MTAy",
+        "level0": {
+          "first_name": "JustFirst"
+        }
+      }
+    ]
+  }
+]

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/mutations.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/mutations.graphql
@@ -15,6 +15,9 @@ type Mutation {
     updateCityName(in: CityNameInput): City @mutation(typeName: UPDATE)
     updateTitleAndLanguageForFilm(in: [FilmWithRefInput]): [Film] @mutation(typeName: UPDATE)
 
+    testingListedNestedInputType(in: [NestedInputType!]!): [Customer] @mutation(typeName: UPDATE)
+    testingNestedInputType(in: NestedInputType!): [Customer] @mutation(typeName: UPDATE)
+
     upsertFilmWithTitleAndLanguage(in: [FilmWithRefInput]): [Film] @mutation(typeName: UPSERT)
     upsertCategory(in: CategoryNameInput): Category @mutation(typeName: UPSERT)
     upsertCategories(in: [CategoryNameInput]): [Category] @mutation(typeName: UPSERT)
@@ -102,4 +105,23 @@ type FilmsWrapper {
 input FilmActorValidationInput @table(name: "FILM_ACTOR") {
     id: ID! @nodeId(typeName: "FilmActor")
     actorId: ID @nodeId(typeName: "Actor") @reference(path: {key: "FILM_ACTOR__FILM_ACTOR_ACTOR_ID_FKEY"})
+}
+
+input NestedInputType @table(name: "CUSTOMER"){
+    id: ID! @nodeId(typeName: "Customer")
+    level0: NestedLevel0!
+}
+
+input NestedLevel0 {
+    first_name: String @field(name: "first_name")
+    level1: NestedLevel1
+}
+
+input NestedLevel1 {
+    last_name: String @field(name: "last_name")
+    level2: NestedLevel2
+}
+
+input NestedLevel2 {
+    email: String @field(name: "email")
 }


### PR DESCRIPTION
The ArgumentPresence object failed before for non-record wrapper types since they tried to access from the parent's argument context. This was fixed by using path-string splitting. Now we navigate in to the child's context and stores the argument state, process the fields and then restore the state. 