### PR TITLE
GG-424 support generating batchStore for UPSERTs

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/README.md
+++ b/graphitron-codegen-parent/graphitron-java-codegen/README.md
@@ -182,7 +182,8 @@ The options are the same for both goals.
   * `onExternalFields` - Enable optional selects for external fields.
 * `useJdbcBatchingForDeletes` - Enables JDBC batching for delete operations in generated mutations. Enabled by default. If disabled, improved delete query with returning clause will be generated.
 * `useJdbcBatchingForInserts` - Enables JDBC batching for insert operations in generated mutations. Enabled by default. If disabled, improved insert query with returning clause will be generated.
-* `failOnMerge` - When enabled, code generation will fail if a MERGE (upsert) mutation is encountered. Disabled by default.
+* `failOnMerge` - When enabled, code generation will fail if an upsert mutation with MERGE is encountered. Disabled by default.
+* `generateUpsertAsStore` - Use jOOQ `batchStore` instead of `batchMerge` for upsert mutations. Disabled by default. When enabled, existing records are fetched by primary key before mutation, and only the input-provided fields are applied onto them. This lets jOOQ decide whether to INSERT or UPDATE based on the record state.
 
 See the [pom.xml](https://github.com/sikt-no/graphitron/blob/main/graphitron-example/graphitron-example-spec/pom.xml)
 of _graphitron-example-spec_ for an example on how to configure these settings.
@@ -868,6 +869,8 @@ Note that mutations need either the **@mutation** or the **@service** directive 
 
 > **Important:** The output from generated update and insert mutations are currently incorrect when using JDBC batching.
 > The mutation output is being fetched and filtered based on the input fields rather than returning the actual mutated record(s). To enable improved queries with returning clauses, disable JDBC batching by setting `useJdbcBatchingForInserts` and/or `useJdbcBatchingForDeletes` to `false` in the [query generation settings](#query-generation-settings).
+
+> **Note:** By default, upsert mutations use SQL MERGE via jOOQ's `batchMerge`. If `batchStore` is preferred, enable `generateUpsertAsStore` in the [query generation settings](#query-generation-settings). This changes the generated code to fetch existing records first and use `batchStore`.
 
 ### Custom logic with @service
 The **service** directive allows for full customization of any database operations while still generating data fetchers.

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/configuration/GeneratorConfig.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/configuration/GeneratorConfig.java
@@ -44,6 +44,7 @@ public class GeneratorConfig {
     private static boolean useJdbcBatchingForInserts = true;
     private static boolean requireTypeIdOnNode = false;
     private static boolean validateOverlappingInputFields = true;
+    private static boolean generateUpsertAsStore = false;
     private static boolean failOnMerge = false;
 
     private static int maxAllowedPageSize;
@@ -122,6 +123,7 @@ public class GeneratorConfig {
         requireTypeIdOnNode = mojo.requireTypeIdOnNode();
         optionalSelect = mojo.getOptionalSelect();
         validateOverlappingInputFields = mojo.validateOverlappingInputFields();
+        generateUpsertAsStore = mojo.generateUpsertAsStore();
         failOnMerge = mojo.failOnMerge();
     }
 
@@ -202,6 +204,7 @@ public class GeneratorConfig {
         globalTransforms = List.of();
         recordValidation = new RecordValidation();
         codeGenerationThresholds = new CodeGenerationThresholds();
+        generateUpsertAsStore = false;
     }
 
     public static Set<String> generatorSchemaFiles() {
@@ -350,6 +353,14 @@ public class GeneratorConfig {
 
     public static void setFailOnMerge(boolean fail) {
         failOnMerge = fail;
+    }
+
+    public static boolean generateUpsertAsStore() {
+        return generateUpsertAsStore;
+    }
+
+    public static void setGenerateUpsertAsStore(boolean enable) {
+        generateUpsertAsStore = enable;
     }
 
     public static void setUseOptionalSelects(boolean enable) {

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/VirtualTableRecordField.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/fields/VirtualTableRecordField.java
@@ -1,0 +1,10 @@
+package no.sikt.graphitron.definitions.fields;
+
+import no.sikt.graphitron.definitions.interfaces.GenerationTarget;
+
+/**
+ * Virtual field representing a table record, used when code generation needs a table reference
+ * without a corresponding GraphQL field definition.
+ */
+public record VirtualTableRecordField(String tableName) implements GenerationTarget {
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generate/Generator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generate/Generator.java
@@ -44,5 +44,7 @@ public interface Generator {
 
     boolean failOnMerge();
 
+    boolean generateUpsertAsStore();
+
     OptionalSelect getOptionalSelect();
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/DBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/abstractions/DBMethodGenerator.java
@@ -1,7 +1,7 @@
 package no.sikt.graphitron.generators.abstractions;
 
 import no.sikt.graphitron.configuration.GeneratorConfig;
-import no.sikt.graphitron.definitions.fields.ObjectField;
+import no.sikt.graphitron.definitions.interfaces.GenerationTarget;
 import no.sikt.graphitron.definitions.objects.ObjectDefinition;
 import no.sikt.graphitron.generators.codebuilding.VariableNames;
 import no.sikt.graphitron.javapoet.MethodSpec;
@@ -18,17 +18,25 @@ import static no.sikt.graphitron.mappings.JavaPoetClassName.NODE_ID_STRATEGY;
  * Generic select query generation functionality is contained within this class.
  * @param <T> Field type that this generator operates on.
  */
-abstract public class DBMethodGenerator<T extends ObjectField> extends AbstractSchemaMethodGenerator<T, ObjectDefinition> {
+abstract public class DBMethodGenerator<T extends GenerationTarget> extends AbstractSchemaMethodGenerator<T, ObjectDefinition> {
     public DBMethodGenerator(ObjectDefinition localObject, ProcessedSchema processedSchema) {
         super(localObject, processedSchema);
     }
 
     @Override
     public MethodSpec.Builder getDefaultSpecBuilder(String methodName, TypeName returnType) {
+        return getDefaultSpecBuilder(methodName, returnType, false);
+    }
+
+    /**
+     * @param skipNodeIdStrategy If true, the node ID strategy parameter is never added,
+     *                           regardless of the global {@link GeneratorConfig#shouldMakeNodeStrategy()} setting.
+     */
+    public MethodSpec.Builder getDefaultSpecBuilder(String methodName, TypeName returnType, boolean skipNodeIdStrategy) {
         return super
                 .getDefaultSpecBuilder(methodName, returnType)
                 .addModifiers(Modifier.STATIC)
                 .addParameter(DSL_CONTEXT.className, VariableNames.VAR_CONTEXT)
-                .addParameterIf(GeneratorConfig.shouldMakeNodeStrategy(), NODE_ID_STRATEGY.className, VAR_NODE_STRATEGY);
+                .addParameterIf(GeneratorConfig.shouldMakeNodeStrategy() && !skipNodeIdStrategy, NODE_ID_STRATEGY.className, VAR_NODE_STRATEGY);
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -27,8 +27,7 @@ import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.wrapArra
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
-import static no.sikt.graphitron.mappings.TableReflection.getJavaFieldNamesForKey;
-import static no.sikt.graphitron.mappings.TableReflection.getTableByJavaFieldName;
+import static no.sikt.graphitron.mappings.TableReflection.*;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -687,9 +686,20 @@ public class FormatCodeBlocks {
      * Returns condition for filtering on resolver key.
      */
     public static CodeBlock inResolverKeysBlock(String resolverKeyParamName, FetchContext context) {
+        return inResolverKeysBlock(resolverKeyParamName, context.getResolverKey().key(), context.getTargetTableName(), context.getTargetAlias());
+    }
+
+    /**
+     * Returns condition for filtering on resolver key, using the table's primary key.
+     */
+    public static CodeBlock inResolverKeysBlock(String resolverKeyParamName, String targetTableJavaName) {
+        return inResolverKeysBlock(resolverKeyParamName, getPrimaryKeyForTable(targetTableJavaName).orElseThrow(), targetTableJavaName, targetTableJavaName);
+    }
+
+    private static CodeBlock inResolverKeysBlock(String resolverKeyParamName, Key<?> key, String tableName, String alias) {
         return CodeBlock.of(
                 "$1L.in($2N.stream().map($3N -> $3N.key().valuesRow()).toList())",
-                wrapRow(commaSeparatedKeyFields(context.getResolverKey().key(), context.getTargetTableName(), context.getTargetAlias())),
+                wrapRow(commaSeparatedKeyFields(key, tableName, alias)),
                 resolverKeyParamName,
                 VAR_ITERATOR
         );
@@ -726,7 +736,7 @@ public class FormatCodeBlocks {
     }
 
     public static CodeBlock getPrimaryKeyFieldsWithTableAliasBlock(String targetAlias) {
-        return CodeBlock.of("$N.fields($L)", targetAlias, getPrimaryKeyFieldsBlock(targetAlias));
+        return CodeBlock.of("$N.fields($L)", targetAlias, getPrimaryKeyFieldsArrayBlock(targetAlias));
     }
 
     public static CodeBlock getPrimaryKeyFieldsWithTableAliasBlock(String targetAlias, String direction) {
@@ -739,11 +749,11 @@ public class FormatCodeBlocks {
     public static CodeBlock getPrimaryKeyFieldsWithTableAliasBlock(String targetAlias, CodeBlock sortOrder) {
         return CodeBlock.of(
                 "$T.of($N.fields($L)).map(f -> f.sort($L)).toArray($T[]::new)",
-                STREAM.className, targetAlias, getPrimaryKeyFieldsBlock(targetAlias),
+                STREAM.className, targetAlias, getPrimaryKeyFieldsArrayBlock(targetAlias),
                 sortOrder, SORT_FIELD.className);
     }
 
-    private static @NotNull CodeBlock getPrimaryKeyFieldsBlock(String target) {
+    private static @NotNull CodeBlock getPrimaryKeyFieldsArrayBlock(String target) {
         return CodeBlock.of("$L.getPrimaryKey().getFieldsArray()", target);
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
@@ -18,6 +18,7 @@ import no.sikt.graphitron.generators.codebuilding.VariablePrefix;
 import no.sikt.graphitron.generators.codeinterface.wiring.WiringContainer;
 import no.sikt.graphitron.generators.context.InputParser;
 import no.sikt.graphitron.generators.context.MapperContext;
+import no.sikt.graphitron.generators.db.FetchTableRecordDBMethodGenerator;
 import no.sikt.graphitron.javapoet.CodeBlock;
 import no.sikt.graphitron.javapoet.MethodSpec;
 import no.sikt.graphitron.javapoet.TypeName;
@@ -38,7 +39,10 @@ import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
 import static no.sikt.graphitron.generators.context.NodeIdReferenceHelpers.resolveColumnNamesForNodeIdField;
 import static no.sikt.graphitron.generators.dto.DTOGenerator.getDTOGetterMethodNameForField;
-import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
+import static no.sikt.graphitron.javapoet.CodeBlock.declare;
+import static no.sikt.graphitron.mappings.JavaPoetClassName.FUNCTION;
+import static no.sikt.graphitron.mappings.JavaPoetClassName.RESOLVER_HELPERS;
+import static no.sikt.graphitron.mappings.TableReflection.getRecordClass;
 import static no.sikt.graphql.naming.GraphQLReservedName.*;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -48,7 +52,8 @@ import static org.apache.commons.lang3.StringUtils.uncapitalize;
 public class OperationMethodGenerator extends DataFetcherMethodGenerator {
     private static final String
             RESPONSE_NAME = internalPrefix("response"),
-            TRANSFORMER_LAMBDA_NAME = internalPrefix("recordTransform");
+            TRANSFORMER_LAMBDA_NAME = internalPrefix("recordTransform"),
+            FETCHED_RECORDS_VAR_SUFFIX = "ForFetchRecords";
 
     public OperationMethodGenerator(ObjectDefinition localObject, ProcessedSchema processedSchema) {
         super(localObject, processedSchema);
@@ -57,6 +62,7 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
     @Override
     public MethodSpec generate(ObjectField target) {
         var isMutationReturningData = processedSchema.isDeleteMutationWithReturning(target) || processedSchema.isInsertMutationWithReturning(target);
+        var isBatchStoreMutation = GeneratorConfig.generateUpsertAsStore() && target.hasMutationType() && target.getMutationType().equals(MutationType.UPSERT);
         var parser = new InputParser(target, processedSchema);
         var methodCall = getMethodCall(target, parser, false); // Note, do this before declaring services.
         dataFetcherWiring.add(new WiringContainer(target.getName(), getLocalObject().getName(), target.getName()));
@@ -66,13 +72,42 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
                 .beginControlFlow("return $N ->", VAR_ENV)
                 .addCode(extractParams(target))
                 .addCode(declareContextArgs(target))
-                .addCode(transformInputs(target, parser))
+                .addCode(transformInputs(target, parser, isBatchStoreMutation))
                 .addCode(validateInputs(parser))
+                .addCodeIf(isBatchStoreMutation, () -> fetchExistingRecordsAndPrepareForStore(parser))
                 .addCode(declareAllServiceClasses(target.getName()))
                 .addCodeIf(!isMutationReturningData && localObject.getName().equals(SCHEMA_MUTATION.getName()),
                         () -> getMethodCall(target, parser, true))
                 .addCode(methodCall)
                 .endControlFlow("") // Keep this, logic to set semicolon only kicks in if a string is set.
+                .build();
+    }
+
+    /**
+     * @return Code block that fetches existing records by primary key and prepares input records for store.
+     */
+    private CodeBlock fetchExistingRecordsAndPrepareForStore(InputParser parser) {
+        var recordInput = parser.getJOOQRecords().entrySet().stream().findFirst().orElseThrow();
+        var targetTable = processedSchema.getInputType(recordInput.getValue().getTypeName()).getTable();
+
+        var fetchedRecordsVariableName = inputPrefix(recordInput.getKey() + FETCHED_RECORDS_VAR_SUFFIX);
+        var fetchRecordsMethodName = FetchTableRecordDBMethodGenerator.getMethodName(getRecordClass(targetTable.getName()).orElseThrow().getSimpleName());
+
+        var fetchTableRecordsCall = CodeBlock.of("$L.$L($L, $L)",
+                asQueryClass(localObject.getName()),
+                fetchRecordsMethodName,
+                asMethodCall(VAR_TRANSFORMER, METHOD_CONTEXT_NAME),
+                !recordInput.getValue().isIterableWrapped() ? listOf(fetchedRecordsVariableName) : fetchedRecordsVariableName
+        );
+
+        return CodeBlock.builder()
+                .add(declare(internalPrefix("existingRecords"), fetchTableRecordsCall))
+                .add(declare(inputPrefix(recordInput.getKey()),
+                        "$T.prepareRecordsForStore($N, $N)",
+                        RESOLVER_HELPERS.className,
+                        internalPrefix("existingRecords"),
+                        fetchedRecordsVariableName)
+                )
                 .build();
     }
 
@@ -357,7 +392,7 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
     /**
      * @return CodeBlock for declaring the transformer class and calling it on each record input.
      */
-    private CodeBlock transformInputs(ObjectField field, InputParser parser) {
+    private CodeBlock transformInputs(ObjectField field, InputParser parser, boolean isBatchStoreMutation) {
         if (!parser.hasRecords()) {
             if (field.hasServiceReference()) {
                 return declareTransform();
@@ -375,7 +410,7 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
         var inputObjects = field.getNonReservedArguments().stream().filter(processedSchema::isInputType).toList();
         for (var in : inputObjects) {
             var context = MapperContext.createResolverContext(in, true, processedSchema);
-            code.add(declareRecords(context, 0));
+            code.add(declareRecords(context, 0, isBatchStoreMutation));
             recordCode.add(unwrapRecords(context));
         }
 
@@ -503,14 +538,16 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
         }
     }
 
-    private CodeBlock declareRecords(MapperContext context, int recursion) {
+    private CodeBlock declareRecords(MapperContext context, int recursion, boolean isBatchStoreMutation) {
         recursionCheck(recursion);
         if (!context.targetIsType()) {
             return CodeBlock.empty();
         }
 
         var target = context.getTarget();
-        var declareBlock = CodeBlock.declare(inputPrefix(asListedRecordNameIf(target.getName(), context.isIterable())), context.transformInputRecord());
+        var baseName = inputPrefix(asListedRecordNameIf(target.getName(), context.isIterable()));
+        var variableName = baseName + (isBatchStoreMutation ? FETCHED_RECORDS_VAR_SUFFIX : "");
+        var declareBlock = declare(variableName, context.transformInputRecord());
         if (context.hasJavaRecordReference()) {
             return declareBlock; // If the input type is a Java record, no further records should be declared.
         }
@@ -528,7 +565,7 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
                         .getFields()
                         .stream()
                         .filter(processedSchema::isInputType)
-                        .map(in -> declareRecords(context.iterateContext(in), recursion + 1))
+                        .map(in -> declareRecords(context.iterateContext(in), recursion + 1, isBatchStoreMutation))
                         .toList()
         );
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/BatchUpdateDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/BatchUpdateDBMethodGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.graphitron.generators.db;
 
+import no.sikt.graphitron.configuration.GeneratorConfig;
 import no.sikt.graphitron.definitions.fields.InputField;
 import no.sikt.graphitron.definitions.fields.ObjectField;
 import no.sikt.graphitron.definitions.fields.containedtypes.MutationType;
@@ -30,12 +31,14 @@ import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
  * Generator that creates the default data mutation methods.
  */
 public class BatchUpdateDBMethodGenerator extends DBMethodGenerator<ObjectField> {
-    private static final Map<MutationType, String> mutationConverter = Map.of(
-            MutationType.UPDATE, "batchUpdate",
-            MutationType.DELETE, "batchDelete",
-            MutationType.INSERT, "batchInsert",
-            MutationType.UPSERT, "batchMerge"
-    );
+    private static String batchMethodName(MutationType type) {
+        return switch (type) {
+            case UPDATE -> "batchUpdate";
+            case DELETE -> "batchDelete";
+            case INSERT -> "batchInsert";
+            case UPSERT -> GeneratorConfig.generateUpsertAsStore() ? "batchStore" : "batchMerge";
+        };
+    }
 
     private static final String VARIABLE_RECORD_LIST = internalPrefix("recordList"), CONFIG = internalPrefix("config");
 
@@ -51,7 +54,7 @@ public class BatchUpdateDBMethodGenerator extends DBMethodGenerator<ObjectField>
      */
     @Override
     public MethodSpec generate(ObjectField target) {
-        var recordMethod = mutationConverter.get(target.getMutationType());
+        var recordMethod = batchMethodName(target.getMutationType());
         if (recordMethod == null) {
             return MethodSpec.methodBuilder(target.getName()).build();
         }
@@ -75,7 +78,7 @@ public class BatchUpdateDBMethodGenerator extends DBMethodGenerator<ObjectField>
             recordInputs.forEach((name, type) -> code.addStatement("$N.$L($N)", VARIABLE_RECORD_LIST, type.isIterableWrapped() ? "addAll" : "add", inputPrefix(name)));
         }
 
-        if (target.hasMutationType() && target.getMutationType() == MutationType.UPSERT) {
+        if (target.hasMutationType() && target.getMutationType() == MutationType.UPSERT && !GeneratorConfig.generateUpsertAsStore()) {
             recordInputs.entrySet().stream()
                     .map(it -> findNodeIdInJooqRecordInputTypes(it.getKey(), it.getValue()))
                     .filter(Optional::isPresent)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/DBClassGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/DBClassGenerator.java
@@ -77,7 +77,8 @@ public class DBClassGenerator extends AbstractSchemaClassGenerator<ObjectDefinit
                         new ServiceResultFetchDBMethodGenerator(target, processedSchema),
                         new SelectHelperDBMethodGenerator(target, processedSchema),
                         new NodeSelectHelperDBMethodGenerator(target, processedSchema, objectFieldsReturningNode),
-                        new EntitySelectHelperDBMethodGenerator(target, processedSchema)
+                        new EntitySelectHelperDBMethodGenerator(target, processedSchema),
+                        new FetchTableRecordDBMethodGenerator(target, processedSchema)
                 )
         ).build();
         warnOrCrashIfMethodsExceedsBounds(typeSpec);

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchTableRecordDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchTableRecordDBMethodGenerator.java
@@ -1,0 +1,88 @@
+package no.sikt.graphitron.generators.db;
+
+import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.definitions.fields.ObjectField;
+import no.sikt.graphitron.definitions.fields.VirtualTableRecordField;
+import no.sikt.graphitron.definitions.fields.containedtypes.MutationType;
+import no.sikt.graphitron.definitions.objects.ObjectDefinition;
+import no.sikt.graphitron.generators.abstractions.DBMethodGenerator;
+import no.sikt.graphitron.javapoet.CodeBlock;
+import no.sikt.graphitron.javapoet.MethodSpec;
+import no.sikt.graphitron.javapoet.ParameterizedTypeName;
+import no.sikt.graphql.schema.ProcessedSchema;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks.inResolverKeysBlock;
+import static no.sikt.graphitron.generators.codebuilding.VariableNames.VAR_CONTEXT;
+import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.internalPrefix;
+import static no.sikt.graphitron.mappings.TableReflection.getRecordClass;
+import static no.sikt.graphitron.mappings.TableReflection.getTableJavaFieldNameByTableName;
+
+/**
+ * Generator that creates methods for fetching existing table records by primary key.
+ * Used in store-based upserts to retrieve current DB state before mutating data.
+ */
+public class FetchTableRecordDBMethodGenerator extends DBMethodGenerator<VirtualTableRecordField> {
+
+    public static final String PRIMARY_KEYS = "primaryKeys";
+
+    public FetchTableRecordDBMethodGenerator(ObjectDefinition localObject, ProcessedSchema processedSchema) {
+        super(localObject, processedSchema);
+    }
+
+    /**
+     * @param target A {@link VirtualTableRecordField} identifying the table to fetch records from.
+     * @return A method that fetches records from the target table matching the primary keys of the input records.
+     */
+    @Override
+    public MethodSpec generate(VirtualTableRecordField target) {
+        var tableJavaName = getTableJavaFieldNameByTableName(target.tableName()).orElse(target.tableName());
+        var recordClass = getRecordClass(target.tableName()).orElseThrow();
+        var methodName = getMethodName(recordClass.getSimpleName());
+
+        var code = CodeBlock.builder()
+                .add("return $N.selectFrom($N)\n", VAR_CONTEXT, tableJavaName)
+                .indent()
+                .indent()
+                .add(".where($L)\n", inResolverKeysBlock(internalPrefix(PRIMARY_KEYS), tableJavaName))
+                .addStatement(".fetch()")
+                .unindent()
+                .unindent()
+                .build();
+
+
+        return getDefaultSpecBuilder(methodName, ParameterizedTypeName.get(List.class, recordClass), true)
+                .addParameter(ParameterizedTypeName.get(List.class, recordClass), internalPrefix(PRIMARY_KEYS))
+                .addCode(code)
+                .build();
+    }
+
+    /**
+     * @return The generated method name for fetching records of the given type, e.g. {@code "fetchCustomerRecords"}.
+     */
+    public static String getMethodName(String recordClassName) {
+        return "fetch" + recordClassName + "s";
+    }
+
+    @Override
+    public List<MethodSpec> generateAll() {
+        if (GeneratorConfig.generateUpsertAsStore()) {
+            Set<String> tablesWithUpsert = localObject.getFields().stream()
+                    .filter(ObjectField::hasMutationType)
+                    .filter(it -> it.getMutationType().equals(MutationType.UPSERT))
+                    .map(processedSchema::findInputTables)
+                    .flatMap(Collection::stream)
+                    .map(it -> it.getTable().getName())
+                    .collect(Collectors.toSet());
+
+            return tablesWithUpsert.stream()
+                    .map(it -> generate(new VirtualTableRecordField(it)))
+                    .toList();
+        }
+        return List.of();
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/MutationValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/MutationValidator.java
@@ -72,11 +72,11 @@ class MutationValidator extends AbstractSchemaValidator {
                 .filter(it -> it.hasMutationType() && !new InputParser(it, schema).hasJOOQRecords())
                 .forEach(it -> addErrorMessage("Mutations must have at least one table attached when generating resolvers with queries. Mutation '%s' has no tables attached.", it.getName()));
 
-        if (GeneratorConfig.failOnMerge()) {
+        if (GeneratorConfig.failOnMerge() && !GeneratorConfig.generateUpsertAsStore()) {
             mutations
                     .stream()
                     .filter(it -> it.hasMutationType() && it.getMutationType() == MutationType.UPSERT)
-                    .forEach(it -> addErrorMessage("MERGE generation is disabled (failOnMerge is enabled), but mutation '%s' uses UPSERT.", it.getName()));
+                    .forEach(it -> addErrorMessage("MERGE generation is disabled (failOnMerge is enabled), but mutation '%s' uses UPSERT. Possible workaround is enabling generateUpsertAsStore.", it.getName()));
         }
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/datafetchers/standard/edit/UpsertAsStoreResolverTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/datafetchers/standard/edit/UpsertAsStoreResolverTest.java
@@ -1,0 +1,87 @@
+package no.sikt.graphitron.datafetchers.standard.edit;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.generators.datafetchers.operations.OperationClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_INPUT_TABLE;
+
+public class UpsertAsStoreResolverTest extends GeneratorTest {
+
+    @Override
+    protected String getSubpath() {
+        return "datafetchers/edit/standard/withBatching";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_INPUT_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new OperationClassGenerator(schema));
+    }
+
+    @BeforeEach
+    void setUp() {
+        GeneratorConfig.setGenerateUpsertAsStore(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GeneratorConfig.setGenerateUpsertAsStore(false);
+    }
+
+    @Test
+    @DisplayName("Upsert as store")
+    void withUpsertAsStore() {
+        assertGeneratedContentContains("upsertAsStore",
+                """
+                    return _iv_env -> {
+                        CustomerInputTable _mi_in = ResolverHelpers.transformDTO(_iv_env.getArgument("in"), CustomerInputTable.class);
+                        var _iv_transform = new RecordTransformer(_iv_env);
+                        var _mi_inRecordForFetchRecords = _iv_transform.customerInputTableToJOOQRecord(_mi_in, _iv_transform.getArgumentPresence().child("in"), "in");
+
+                        var _iv_existingRecords = MutationDBQueries.fetchCustomerRecords(_iv_transform.getCtx(), List.of(_mi_inRecordForFetchRecords));
+
+                        var _mi_inRecord = ResolverHelpers.prepareRecordsForStore(_iv_existingRecords, _mi_inRecordForFetchRecords);
+
+                        MutationDBQueries.mutationForMutation(_iv_transform.getCtx(), _mi_inRecord);
+                        return new DataFetcherHelper(_iv_env).load((_iv_ctx, _iv_selectionSet) -> MutationDBQueries.mutationForMutation(_iv_ctx, _mi_inRecord, _iv_selectionSet));
+                    };
+                """
+        );
+    }
+
+    @Test
+    @DisplayName("Upsert as store with listed input")
+    void withUpsertAsStoreListed() {
+        assertGeneratedContentContains("upsertAsStoreListed",
+                """
+                    return _iv_env -> {
+                        List<CustomerInputTable> _mi_in = ResolverHelpers.transformDTOList(_iv_env.getArgument("in"), CustomerInputTable.class);
+                        var _iv_transform = new RecordTransformer(_iv_env);
+                        var _mi_inRecordListForFetchRecords = _iv_transform.customerInputTableToJOOQRecord(_mi_in, _iv_transform.getArgumentPresence().child("in"), "in");
+
+                        var _iv_existingRecords = MutationDBQueries.fetchCustomerRecords(_iv_transform.getCtx(), _mi_inRecordListForFetchRecords);
+
+                        var _mi_inRecordList = ResolverHelpers.prepareRecordsForStore(_iv_existingRecords, _mi_inRecordListForFetchRecords);
+
+                        MutationDBQueries.mutationForMutation(_iv_transform.getCtx(), _mi_inRecordList);
+                        return new DataFetcherHelper(_iv_env).load((_iv_ctx, _iv_selectionSet) -> MutationDBQueries.mutationForMutation(_iv_ctx, _mi_inRecordList, _iv_selectionSet));
+                    };
+                """
+        );
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/BatchingQueryWithStoreTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/edit/BatchingQueryWithStoreTest.java
@@ -1,0 +1,48 @@
+package no.sikt.graphitron.queries.edit;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.UpdateOnlyDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_INPUT_TABLE;
+
+@DisplayName("Mutation queries - Queries for updating data with JDBC batching")
+public class BatchingQueryWithStoreTest extends GeneratorTest {
+    @Override
+    protected String getSubpath() {
+        return "queries/edit/withBatching";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_INPUT_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new UpdateOnlyDBClassGenerator(schema));
+    }
+
+    @BeforeEach
+    void setUp() {
+        GeneratorConfig.setGenerateUpsertAsStore(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GeneratorConfig.setGenerateUpsertAsStore(false);
+    }
+
+    @Test
+    @DisplayName("Upsert as store")
+    void upsertAsStore() {
+        assertGeneratedContentContains("upsert", ".batchStore(_mi_inRecord)");
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/FetchTableRecordTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/FetchTableRecordTest.java
@@ -1,0 +1,60 @@
+package no.sikt.graphitron.queries.fetch;
+
+import no.sikt.graphitron.common.GeneratorTest;
+import no.sikt.graphitron.common.configuration.SchemaComponent;
+import no.sikt.graphitron.configuration.GeneratorConfig;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.FetchTableRecordOnlyDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.SchemaComponent.CUSTOMER_INPUT_TABLE;
+
+public class FetchTableRecordTest extends GeneratorTest {
+
+    @Override
+    protected String getSubpath() {
+        return "queries/fetch/tableRecord";
+    }
+
+    @Override
+    protected Set<SchemaComponent> getComponents() {
+        return makeComponents(CUSTOMER_INPUT_TABLE);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new FetchTableRecordOnlyDBClassGenerator(schema));
+    }
+
+    @BeforeEach
+    void setUp() {
+        GeneratorConfig.setGenerateUpsertAsStore(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GeneratorConfig.setGenerateUpsertAsStore(false);
+    }
+
+    @Test
+    @DisplayName("Default case")
+    void defaultCase() {
+        assertGeneratedContentMatches("default");
+    }
+
+    @Test
+    @DisplayName("When multiple UPSERT mutations exist, one record fetching method should be generated for each table")
+    void multipleTables() {
+        assertGeneratedContentContains("multipleTables",
+                " fetchAddressRecords(",
+                " fetchCustomerRecords("
+        );
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/reducedgenerators/FetchTableRecordOnlyDBClassGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/reducedgenerators/FetchTableRecordOnlyDBClassGenerator.java
@@ -1,0 +1,22 @@
+package no.sikt.graphitron.reducedgenerators;
+
+import no.sikt.graphitron.definitions.objects.ObjectDefinition;
+import no.sikt.graphitron.generators.db.DBClassGenerator;
+import no.sikt.graphitron.generators.db.FetchTableRecordDBMethodGenerator;
+import no.sikt.graphitron.javapoet.TypeSpec;
+import no.sikt.graphql.schema.ProcessedSchema;
+
+import java.util.List;
+
+public class FetchTableRecordOnlyDBClassGenerator extends DBClassGenerator {
+    public FetchTableRecordOnlyDBClassGenerator(ProcessedSchema processedSchema) {
+        super(processedSchema);
+    }
+
+    @Override
+    public TypeSpec generate(ObjectDefinition target) {
+        return getSpec(target.getName(),
+                List.of(new FetchTableRecordDBMethodGenerator(target, processedSchema))
+        ).build();
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/MutationTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/MutationTest.java
@@ -170,9 +170,23 @@ public class MutationTest extends ValidationTest { // TODO: Some of these tests 
         try {
             GeneratorConfig.setFailOnMerge(true);
             assertErrorsContain("upsert", Set.of(CUSTOMER_INPUT_TABLE),
-                    "MERGE generation is disabled (failOnMerge is enabled), but mutation 'upsertCustomer' uses UPSERT.");
+                    "MERGE generation is disabled (failOnMerge is enabled), but mutation 'upsertCustomer' uses UPSERT. " +
+                            "Possible workaround is enabling generateUpsertAsStore.");
         } finally {
             GeneratorConfig.setFailOnMerge(false);
+        }
+    }
+
+    @Test
+    @DisplayName("Upsert mutation should not fail validation when both failOnMerge and generateUpsertAsStore is enabled")
+    void failOnMergeButStoreEnabled() {
+        try {
+            GeneratorConfig.setFailOnMerge(true);
+            GeneratorConfig.setGenerateUpsertAsStore(true);
+            getProcessedSchema("upsert", Set.of(CUSTOMER_INPUT_TABLE));
+        } finally {
+            GeneratorConfig.setFailOnMerge(false);
+            GeneratorConfig.setGenerateUpsertAsStore(false);
         }
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/datafetchers/edit/standard/withBatching/upsertAsStore/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/datafetchers/edit/standard/withBatching/upsertAsStore/schema.graphqls
@@ -1,0 +1,3 @@
+type Mutation {
+  mutation(in: CustomerInputTable): ID @mutation(typeName: UPSERT)
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/datafetchers/edit/standard/withBatching/upsertAsStoreListed/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/datafetchers/edit/standard/withBatching/upsertAsStoreListed/schema.graphqls
@@ -1,0 +1,3 @@
+type Mutation {
+  mutation(in: [CustomerInputTable]): [ID] @mutation(typeName: UPSERT)
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/default/expected/MutationDBQueries.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/default/expected/MutationDBQueries.java
@@ -1,0 +1,16 @@
+package fake.code.generated.queries.query;
+
+import static no.sikt.graphitron.jooq.generated.testdata.pg_catalog.Tables.*;
+import static no.sikt.graphitron.jooq.generated.testdata.public_.Tables.*;
+import java.util.List;
+import no.sikt.graphitron.jooq.generated.testdata.public_.tables.records.CustomerRecord;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+
+public class MutationDBQueries {
+    public static List<CustomerRecord> fetchCustomerRecords(DSLContext _iv_ctx, List<CustomerRecord> _iv_primaryKeys) {
+        return _iv_ctx.selectFrom(CUSTOMER)
+                .where(DSL.row(CUSTOMER.CUSTOMER_ID).in(_iv_primaryKeys.stream().map(_iv_it -> _iv_it.key().valuesRow()).toList()))
+                .fetch();
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/default/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/default/schema.graphqls
@@ -1,0 +1,3 @@
+type Mutation {
+  mutation(in: CustomerInputTable): ID @mutation(typeName: UPSERT)
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/multipleTables/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/tableRecord/multipleTables/schema.graphqls
@@ -1,0 +1,9 @@
+type Mutation {
+  mutation1(in: CustomerInputTable): ID @mutation(typeName: UPSERT)
+  mutation2(in: AddressInputTable): ID @mutation(typeName: UPSERT)
+  mutation3(in: CustomerInputTable): ID @mutation(typeName: UPSERT)
+}
+
+input AddressInputTable @table(name: "ADDRESS") {
+  id: ID!
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/ResolverHelpers.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/ResolverHelpers.java
@@ -1,11 +1,11 @@
 package no.sikt.graphql.helpers.resolvers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jooq.Field;
+import org.jooq.UpdatableRecord;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ResolverHelpers {
@@ -88,5 +88,54 @@ public class ResolverHelpers {
             map.put((String) keysAndValues[i], keysAndValues[i + 1]);
         }
         assertSameColumnValues(map);
+    }
+
+    /**
+     * Prepares jOOQ table records for a {@code store()} call by reconciling input with existing database state.
+     * For records with matching keys, non-PK fields that are touched in {@code inputRecords} are applied onto
+     * the corresponding record in {@code existingRecords}, preparing them for UPDATE.
+     * For records without a match, the record is added as-is with its PK fields marked as touched to trigger an INSERT.
+     *
+     * @param existingRecords records fetched from the database
+     * @param inputRecords new records whose touched fields will be applied
+     * @return list of records ready for store
+     */
+    public static <T extends UpdatableRecord<T>> List<T> prepareRecordsForStore(List<T> existingRecords, List<T> inputRecords) {
+        var preparedRecords = new ArrayList<T>();
+        var existingByKey = existingRecords.stream().collect(Collectors.toMap(UpdatableRecord::key, Function.identity()));
+        inputRecords.forEach(r -> {
+            if (existingByKey.containsKey(r.key())) {
+                var prepared = applyTouchedFields(existingByKey.get(r.key()), r);
+                preparedRecords.add(prepared);
+            } else {
+                r.key().fieldStream().forEach(f -> r.changed(f, true)); // Set PK to changed to trigger an INSERT
+                preparedRecords.add(r);
+            }
+        });
+        return preparedRecords;
+    }
+
+    /**
+     * Prepares a single record for a jOOQ {@code store()} call by matching it against existing records.
+     *
+     * @param existingRecords records fetched from the database, matched by primary key
+     * @param inputRecord record whose touched fields will be applied
+     * @return the prepared record, or {@code null} if no match was found
+     */
+    public static <T extends UpdatableRecord<T>> T prepareRecordsForStore(List<T> existingRecords, T inputRecord) {
+        return prepareRecordsForStore(existingRecords, List.of(inputRecord)).stream().findFirst()
+                .orElseThrow(() -> new RuntimeException("Preparing TableRecord for store failed."));
+    }
+
+    private static <T extends UpdatableRecord<T>> T applyTouchedFields(T existingRecord, T inputRecord) {
+        inputRecord.fieldStream()
+                .filter(it -> existingRecord.key().fieldStream().noneMatch(pkField -> pkField.equals(it)))
+                .filter(inputRecord::changed)
+                .forEach(field -> setField(existingRecord, field, inputRecord));
+        return existingRecord;
+    }
+
+    private static <V> void setField(UpdatableRecord<?> target, Field<V> field, UpdatableRecord<?> source) {
+        target.set(field, source.get(field));
     }
 }

--- a/graphitron-common/src/test/java/no/sikt/graphql/helpers/resolvers/PrepareTableRecordsForStoreTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/helpers/resolvers/PrepareTableRecordsForStoreTest.java
@@ -1,0 +1,104 @@
+package no.sikt.graphql.helpers.resolvers;
+
+import no.sikt.jooq.example.VacationRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static no.sikt.jooq.example.Vacation.VACATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ResolverHelpers - prepareRecordsForStore")
+class PrepareTableRecordsForStoreTest {
+
+    @Test
+    @DisplayName("Should copy touched fields from input to stored record")
+    void shouldCopyTouchedFields() {
+        var stored = new VacationRecord(1L, "Beach trip");
+        stored.touched(false);
+
+        var input = new VacationRecord();
+        input.setVacationId(1L);
+        input.set(VACATION.DESCRIPTION, "Mountain trip");
+
+        var result = ResolverHelpers.prepareRecordsForStore(List.of(stored), input);
+
+        assertThat(result.getDescription())
+                .withFailMessage("Description from input record should be set in the resulting record.")
+                .isEqualTo("Mountain trip");
+
+        assertThat(result.touched(VACATION.DESCRIPTION))
+                .withFailMessage("The description field from the input record should be 'touched' in the merged record.")
+                .isEqualTo(true);
+
+        assertThat(result.touched(VACATION.VACATION_ID))
+                .withFailMessage("Primary key field should not be 'touched'.")
+                .isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("Should preserve untouched fields from stored record")
+    void shouldPreserveUntouchedFields() {
+        var stored = new VacationRecord(1L, "Beach trip");
+        stored.touched(false);
+
+        var input = new VacationRecord();
+        input.setVacationId(1L);
+
+        var result = ResolverHelpers.prepareRecordsForStore(List.of(stored), input);
+
+        assertThat(result.getDescription())
+                .withFailMessage("The description from the stored record should be preserved.")
+                .isEqualTo("Beach trip");
+
+        assertThat(result.touched(VACATION.DESCRIPTION))
+                .withFailMessage("The description field from the input record should not be 'touched'.")
+                .isEqualTo(false);
+    }
+
+
+    @Test
+    @DisplayName("Should merge lists by matching primary keys")
+    void shouldMergeListsByKey() {
+        var stored1 = new VacationRecord(1L, "Beach trip");
+        stored1.touched(false);
+        var stored2 = new VacationRecord(2L, "City tour");
+        stored2.touched(false);
+
+        var input1 = new VacationRecord();
+        input1.setVacationId(1L);
+        input1.set(VACATION.DESCRIPTION, "Updated beach trip");
+
+        var input2 = new VacationRecord();
+        input2.setVacationId(2L);
+        input2.set(VACATION.DESCRIPTION, "Updated city tour");
+
+        var result = ResolverHelpers.prepareRecordsForStore(List.of(stored1, stored2), List.of(input1, input2));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getVacationId()).isEqualTo(1);
+        assertThat(result.get(0).getDescription()).isEqualTo("Updated beach trip");
+
+        assertThat(result.get(1).getVacationId()).isEqualTo(2);
+        assertThat(result.get(1).getDescription()).isEqualTo("Updated city tour");
+    }
+
+    @Test
+    @DisplayName("Should add input record when no matching key in stored records")
+    void shouldAddNewRecordWhenKeyNotFound() {
+        var stored = new VacationRecord(1L, "Beach trip");
+        stored.touched(false);
+
+        var input = new VacationRecord(2L, "Mountain trip");
+
+        var result = ResolverHelpers.prepareRecordsForStore(List.of(stored), List.of(input));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getVacationId()).isEqualTo(2);
+        assertThat(result.get(0).touched(VACATION.VACATION_ID))
+                .withFailMessage("Primary key field should be touched for new records to trigger INSERT.")
+                .isEqualTo(true);
+        assertThat(result.get(0).getDescription()).isEqualTo("Mountain trip");
+    }
+}

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/VacationRecord.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/VacationRecord.java
@@ -21,7 +21,7 @@ public class VacationRecord extends UpdatableRecordImpl<VacationRecord> {
         return (Long) get(0);
     }
 
-    public void setDescription(Long value) {
+    public void setDescription(String value) {
         set(1, value);
     }
 
@@ -39,6 +39,13 @@ public class VacationRecord extends UpdatableRecordImpl<VacationRecord> {
 
     public VacationRecord() {
         super(Vacation.VACATION);
+    }
+
+    public VacationRecord(Long vacationId, String description) {
+        super(Vacation.VACATION);
+        setVacationId(vacationId);
+        setDescription(description);
+        resetTouchedOnNotNull();
     }
 
     @Override

--- a/graphitron-example/graphitron-example-spec/pom.xml
+++ b/graphitron-example/graphitron-example-spec/pom.xml
@@ -83,6 +83,7 @@
                                 <externalReferenceImport>no.sikt.graphitron.example.service.CustomerWithExternalFields</externalReferenceImport>
                             </externalReferenceImports>
                             <makeNodeStrategy>true</makeNodeStrategy>
+                            <generateUpsertAsStore>true</generateUpsertAsStore>
                             <scalars>
                                 <class>
                                     <fullyQualifiedClassName>no.sikt.graphitron.example.service.ConsumerProvidedScalars</fullyQualifiedClassName>

--- a/graphitron-maven-plugin/README.md
+++ b/graphitron-maven-plugin/README.md
@@ -191,17 +191,18 @@ The output is a JSON file (default: `target/graphitron-lsp-config.json`) with th
 
 ### Code Generation Configuration
 
-| Parameter              | Description                                                 | Required | Default                    |
-|------------------------|-------------------------------------------------------------|----------|----------------------------|
-| `jooqGeneratedPackage` | Package containing jOOQ generated classes                   | Yes      | -                          |
-| `outputPackage`        | Package for generated GraphQL code                          | No       | `no.sikt.graphql`          |
-| `outputPath`           | Directory for generated sources                             | No       | `target/generated-sources` |
-| `schemaFiles`          | Pre-transformed schema files (when not using `<transform>`) | No       | -                          |
-| `userSchemaFiles`      | Schema files to expose to clients                           | No       | ***                        |
-| `makeNodeStrategy`     | Enable Relay Global Object Identification                   | No       | `false`                    |
-| `scalars`              | Custom scalar implementations                               | No       | -                          |
-| `maxAllowedPageSize`   | Maximum page size for connections                           | No       | `1000`                     |
-| `failOnMerge`          | Fail code generation if a MERGE (upsert) mutation is found  | No       | `false`                    |
+| Parameter               | Description                                                     | Required | Default                    |
+|-------------------------|-----------------------------------------------------------------|----------|----------------------------|
+| `jooqGeneratedPackage`  | Package containing jOOQ generated classes                       | Yes      | -                          |
+| `outputPackage`         | Package for generated GraphQL code                              | No       | `no.sikt.graphql`          |
+| `outputPath`            | Directory for generated sources                                 | No       | `target/generated-sources` |
+| `schemaFiles`           | Pre-transformed schema files (when not using `<transform>`)     | No       | -                          |
+| `userSchemaFiles`       | Schema files to expose to clients                               | No       | ***                        |
+| `makeNodeStrategy`      | Enable Relay Global Object Identification                       | No       | `false`                    |
+| `scalars`               | Custom scalar implementations                                   | No       | -                          |
+| `maxAllowedPageSize`    | Maximum page size for connections                               | No       | `1000`                     |
+| `failOnMerge`           | Fail code generation if a upsert mutation with `MERGE` is found | No       | `false`                    |
+| `generateUpsertAsStore` | Use jOOQ `batchStore` instead of `batchMerge` for upserts       | No       | `false`                    |
 
 \*\*\* Defaults to `schema.graphql` when using `<transform>`, otherwise defaults to `schemaFiles`.
 

--- a/graphitron-maven-plugin/src/main/java/no/sikt/graphitron/mojo/GenerateMojo.java
+++ b/graphitron-maven-plugin/src/main/java/no/sikt/graphitron/mojo/GenerateMojo.java
@@ -94,11 +94,19 @@ public class GenerateMojo extends AbstractGraphitronMojo implements Generator {
     protected CodeGenerationThresholds codeGenerationThresholds;
 
     /**
-     * When enabled, code generation will fail if a MERGE (upsert) mutation is encountered.
+     * When enabled, code generation will fail if an upsert mutation with MERGE is encountered.
      */
     @Parameter(property = "graphitron.failOnMerge", defaultValue = "false")
     @SuppressWarnings("unused")
     protected boolean failOnMerge;
+
+    /**
+     * Use jOOQ store instead of merge for upsert mutations. When enabled, existing records are fetched
+     * before mutation and input fields are applied onto them, letting jOOQ decide INSERT vs UPDATE.
+     */
+    @Parameter(property = "graphitron.generateUpsertAsStore", defaultValue = "false")
+    @SuppressWarnings("unused")
+    protected boolean generateUpsertAsStore;
 
     @Parameter(property = "generate.optionalSelect")
     @SuppressWarnings("unused")
@@ -240,6 +248,11 @@ public class GenerateMojo extends AbstractGraphitronMojo implements Generator {
     @Override
     public boolean validateOverlappingInputFields() {
         return validateOverlappingInputFields;
+    }
+
+    @Override
+    public boolean generateUpsertAsStore() {
+        return generateUpsertAsStore;
     }
 
     @Override


### PR DESCRIPTION
This change adds a `generateUpsertAsStore` configuration flag (default `false`) that switches generated `@mutation(typeName: UPSERT)` code from jOOQ's `batchMerge` to `batchStore`.
When enabled, the generated resolver fetches existing records by primary key before mutation, applies only the input-provided fields onto them via `ResolverHelpers.prepareRecordsForStore`, and lets jOOQ decide `INSERT` vs `UPDATE` based on the record's internal state.