### PR TITLE
fix compilation error in DTOs for `@record` types with errors and list `@table` fields

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/dto/DTOGenerator.java
@@ -86,7 +86,7 @@ public abstract class DTOGenerator<T extends GenerationTarget> extends AbstractS
                     }
                 });
 
-        if (hasErrors) {
+        if (hasErrors && !isJavaRecord) {
             classBuilder.addMethod(constructorNoErrorsBuilder.build());
         }
         return classBuilder

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/RecordMappingValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/RecordMappingValidator.java
@@ -171,7 +171,8 @@ class RecordMappingValidator extends AbstractSchemaValidator {
                 ? schema.getInputType(field)
                 : schema.getObject(field.getTypeName());
 
-        if (nested != null && !nested.hasJavaRecordReference() && !nested.hasTable()) {
+        if (nested != null && !nested.hasJavaRecordReference() && !nested.hasTable()
+                && !schema.isExceptionOrExceptionUnion(field.getTypeName())) {
             return Optional.of(nested);
         }
         return Optional.empty();

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_record_payload-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/error_handling_query_service_record_payload-1.result.approved.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "allCustomerEmails_recordPayload": {
+            "errors": [
+                {
+                    "__typename": "CustomerEmailsError",
+                    "path": [
+                        "allCustomerEmails_recordPayload"
+                    ],
+                    "message": "You do not have access (Record payload exception)"
+                }
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_record_payload.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/error_handling_query_service_record_payload.graphql
@@ -1,0 +1,10 @@
+# Tests error handling for @record type with list @table field and errors
+{
+    allCustomerEmails_recordPayload {
+        errors {
+            __typename
+            path
+            message
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
@@ -2,6 +2,7 @@ package no.sikt.graphitron.example.service;
 
 import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
 import no.sikt.graphitron.example.service.records.HelloWorldInput;
+import no.sikt.graphitron.example.service.records.CustomerEmailsRecordPayload;
 import no.sikt.graphitron.example.service.records.UpdateCustomerEmailRecord;
 import no.sikt.graphitron.example.service.records.UpdateCustomerEmailResult;
 import org.jooq.DSLContext;
@@ -66,6 +67,10 @@ public class CustomerService {
 
     public List<CustomerRecord> allCustomerEmails_customException() {
         throw new CustomBusinessException("Custom business rule violated: restricted access");
+    }
+
+    public CustomerEmailsRecordPayload allCustomerEmails_recordPayload() {
+        throw new IllegalStateException("Record payload exception");
     }
 
     public List<UpdateCustomerEmailResult> updateCustomerEmail(List<UpdateCustomerEmailRecord> input) {

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/CustomerEmailsRecordPayload.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/CustomerEmailsRecordPayload.java
@@ -1,0 +1,17 @@
+package no.sikt.graphitron.example.service.records;
+
+import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
+
+import java.util.List;
+
+public class CustomerEmailsRecordPayload {
+    private List<CustomerRecord> customers;
+
+    public List<CustomerRecord> getCustomers() {
+        return customers;
+    }
+
+    public void setCustomers(List<CustomerRecord> customers) {
+        this.customers = customers;
+    }
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/errorHandling.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/errorHandling.graphql
@@ -34,6 +34,13 @@ extend type Query {
             method: "allCustomerEmails_customException"
         }
     )
+    #Tests error handling for @record type with list @table field and errors
+    allCustomerEmails_recordPayload: CustomerEmailsRecordPayload @service(
+        service: {
+            className: "no.sikt.graphitron.example.service.CustomerService",
+            method: "allCustomerEmails_recordPayload"
+        }
+    )
 }
 
 type CustomerEmailsPayload{
@@ -42,7 +49,8 @@ type CustomerEmailsPayload{
 }
 
 type CustomerEmailsError implements Error @error(handlers: [
-    {handler: GENERIC, matches: "not allowed", className: "java.lang.IllegalStateException" description: "You do not have access to customer emails"}]) {
+    {handler: GENERIC, matches: "not allowed", className: "java.lang.IllegalStateException" description: "You do not have access to customer emails"},
+    {handler: GENERIC, matches: "Record payload exception", className: "java.lang.IllegalStateException" description: "You do not have access (Record payload exception)"}]) {
     path: [String!]!
     message: String!
 }
@@ -79,4 +87,9 @@ type CustomExceptionError implements Error @error(handlers: [
     {handler: GENERIC, className: "no.sikt.graphitron.example.service.CustomBusinessException", description: "Access to customer emails is restricted by business rules"}]) {
     path: [String!]!
     message: String!
+}
+
+type CustomerEmailsRecordPayload @record(record: {className: "no.sikt.graphitron.example.service.records.CustomerEmailsRecordPayload"}) {
+    customers: [Customer!]
+    errors: [CustomerEmailsError!]
 }


### PR DESCRIPTION
Two issues fixed:
- DTOGenerator: the "no errors" constructor was added unconditionally for `@record` types, producing a duplicate no-arg constructor when the type had both a list @table field (implicit split query) and error fields
- RecordMappingValidator: `@error` types were incorrectly flattened during field mapping validation, causing false validation failures