### PR TITLE
Ikke filtrer bort @asConnection-direktivet

### DIFF
--- a/graphitron-schema-transform/src/main/java/no/fellesstudentsystem/schema_transformer/transform/MakeConnections.java
+++ b/graphitron-schema-transform/src/main/java/no/fellesstudentsystem/schema_transformer/transform/MakeConnections.java
@@ -88,9 +88,6 @@ public class MakeConnections {
             var pageInfo = createPageInfo(queryLocation, !sharableConnectionTypes.isEmpty() ? List.of(SHAREABLE) : List.of());
             typeDefinitionRegistry.add(pageInfo);
         }
-        typeDefinitionRegistry
-                .getDirectiveDefinition(AS_CONNECTION.getName())
-                .ifPresent(typeDefinitionRegistry::remove);
     }
 
     private static Set<String> collectSharableConnectionTypes(List<ObjectTypeDefinition> objects, List<InterfaceTypeDefinition> interfaces) {

--- a/graphitron-schema-transform/src/test/resources/addTagsOnConnectionTypes/expected/schema.graphql
+++ b/graphitron-schema-transform/src/test/resources/addTagsOnConnectionTypes/expected/schema.graphql
@@ -1,3 +1,5 @@
+directive @asConnection(defaultFirstValue: Int = 100, connectionName: String) on FIELD_DEFINITION
+
 schema @link(url : "https://specs.apollo.dev/federation/v2.9", import : ["@tag"]) {
   query: Query
 }

--- a/graphitron-schema-transform/src/test/resources/createNestedPagination/expected/schema.graphql
+++ b/graphitron-schema-transform/src/test/resources/createNestedPagination/expected/schema.graphql
@@ -1,3 +1,5 @@
+directive @asConnection(defaultFirstValue: Int = 100, connectionName: String) on FIELD_DEFINITION
+
 type Query {
     q0(param: String!): T1Connection
     q1(param: String!): [T1]


### PR DESCRIPTION
Jeg trenger at vi beholder dette i det resulterende skjemaet i forbindelse med at jeg eksperimenterer med å støtte native connection-håndtering i graphitron-rewrite.

Så vidt jeg kan se er det helt uproblematisk at selve direktivet blir liggende igjen i skjemaet.