### PR TITLE
GG-343 validate input types don't have both record and table directives

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/InputDirectiveValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/InputDirectiveValidator.java
@@ -1,0 +1,32 @@
+package no.sikt.graphitron.validation;
+
+import no.sikt.graphitron.definitions.fields.ObjectField;
+import no.sikt.graphitron.definitions.objects.RecordObjectDefinition;
+import no.sikt.graphql.schema.ProcessedSchema;
+
+import java.util.List;
+
+import static no.sikt.graphitron.validation.ValidationHandler.addWarningMessage;
+import static no.sikt.graphitron.validation.messages.InputDirectiveWarning.RECORD_TYPE_CONFLICT;
+
+/**
+ * Validates directive combinations on input types.
+ */
+class InputDirectiveValidator extends AbstractSchemaValidator {
+
+    InputDirectiveValidator(ProcessedSchema schema, List<ObjectField> allFields) {
+        super(schema, allFields);
+    }
+
+    @Override
+    void validate() {
+        validateNotUsingBothTableAndRecord();
+    }
+
+    private void validateNotUsingBothTableAndRecord() {
+        schema.getInputTypes().values().stream()
+                .filter(RecordObjectDefinition::hasTable)
+                .filter(RecordObjectDefinition::hasJavaRecordReference)
+                .forEach(input -> addWarningMessage(RECORD_TYPE_CONFLICT, input.getName()));
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/ProcessedDefinitionsValidator.java
@@ -35,6 +35,7 @@ public class ProcessedDefinitionsValidator {
                 new ServiceValidator(schema, allFields),
                 new MutationValidator(schema, allFields),
                 new FieldDirectiveValidator(schema, allFields),
+                new InputDirectiveValidator(schema, allFields),
                 new NodeValidator(schema, allFields),
                 new PaginationValidator(schema, allFields),
                 new FederationValidator(schema, allFields)

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/messages/InputDirectiveWarning.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/messages/InputDirectiveWarning.java
@@ -1,0 +1,24 @@
+package no.sikt.graphitron.validation.messages;
+
+import no.sikt.graphitron.validation.messages.interfaces.WarningMessage;
+
+import static no.sikt.graphql.directives.GenerationDirective.RECORD;
+import static no.sikt.graphql.directives.GenerationDirective.TABLE;
+
+public enum InputDirectiveWarning implements WarningMessage {
+    RECORD_TYPE_CONFLICT(String.format("Input types can only be mapped to one record category (either a jOOQ record " +
+                    "via @%1$s or a Java record via @%2$s), but input type '%%s' has both directives. " +
+                    "Remove @%1$s to preserve the existing behaviour.",
+            TABLE.getName(), RECORD.getName()));
+
+    private final String msg;
+
+    InputDirectiveWarning(String msg) {
+        this.msg = msg;
+    }
+
+    @Override
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InputDirectiveValidationTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InputDirectiveValidationTest.java
@@ -1,0 +1,44 @@
+package no.sikt.graphitron.validation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static no.sikt.graphql.directives.GenerationDirective.RECORD;
+import static no.sikt.graphql.directives.GenerationDirective.TABLE;
+
+@DisplayName("Input directive validation - Checks for conflicting directives on input types")
+public class InputDirectiveValidationTest extends ValidationTest {
+
+    @Override
+    protected String getSubpath() {
+        return super.getSubpath() + "inputDirective";
+    }
+
+    @Test
+    @DisplayName("Input with both @table and @record should log warning")
+    void tableAndRecord() {
+        getProcessedSchema("tableAndRecord");
+        assertWarningsContain(
+                String.format(
+                        "Input types can only be mapped to one record category (either a jOOQ record via @%1$s or a " +
+                                "Java record via @%2$s), but input type 'TestInput' has both directives. Remove @%1$s to " +
+                                "preserve the existing behaviour.",
+                        TABLE.getName(), RECORD.getName()
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("Input with only @table is valid")
+    void tableOnly() {
+        getProcessedSchema("tableOnly");
+        assertNoWarnings();
+    }
+
+    @Test
+    @DisplayName("Input with only @record is valid")
+    void recordOnly() {
+        getProcessedSchema("recordOnly");
+        assertNoWarnings();
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/recordOnly/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/recordOnly/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+    test(in: TestInput): ID @notGenerated
+}
+
+input TestInput @record(record: {className: "no.sikt.graphitron.codereferences.records.CustomerJavaRecord"}) {
+    someID: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/tableAndRecord/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/tableAndRecord/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+    test(in: TestInput): ID @notGenerated
+}
+
+input TestInput @table(name: "ADDRESS") @record(record: {className: "no.sikt.graphitron.codereferences.records.CustomerJavaRecord"}) {
+    someID: ID
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/tableOnly/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/validation/inputDirective/tableOnly/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+    test(in: TestInput): ID @notGenerated
+}
+
+input TestInput @table(name: "ADDRESS") {
+    addressId: Int @field(name: "ADDRESS_ID")
+}


### PR DESCRIPTION
## Overview
**Related issue**: GG-343
**Issue coverage**: partial (error message in follow up PR)
**Backwards compatibility**: yes

## Summary
GraphQL input types in Graphitron schemas currently accepts both `@table` and `@record` directives on the same type, even though an input type can only be mapped to a single record category. A new schema-time validator now gives a warning message naming the offending input type. 

## Notes
- Input types declaring both `@table` and `@record` will produce a build warning. Remove `@table` to preserve the current behaviour, or remove `@record` to switch to jOOQ-record mapping.