### PR TITLE
GG-343 validation error on input types with both record and table directives

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/InputDirectiveValidator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/InputDirectiveValidator.java
@@ -6,8 +6,8 @@ import no.sikt.graphql.schema.ProcessedSchema;
 
 import java.util.List;
 
-import static no.sikt.graphitron.validation.ValidationHandler.addWarningMessage;
-import static no.sikt.graphitron.validation.messages.InputDirectiveWarning.RECORD_TYPE_CONFLICT;
+import static no.sikt.graphitron.validation.ValidationHandler.addErrorMessage;
+import static no.sikt.graphitron.validation.messages.InputDirectiveError.RECORD_TYPE_CONFLICT;
 
 /**
  * Validates directive combinations on input types.
@@ -27,6 +27,6 @@ class InputDirectiveValidator extends AbstractSchemaValidator {
         schema.getInputTypes().values().stream()
                 .filter(RecordObjectDefinition::hasTable)
                 .filter(RecordObjectDefinition::hasJavaRecordReference)
-                .forEach(input -> addWarningMessage(RECORD_TYPE_CONFLICT, input.getName()));
+                .forEach(input -> addErrorMessage(RECORD_TYPE_CONFLICT, input.getName()));
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/messages/InputDirectiveError.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/validation/messages/InputDirectiveError.java
@@ -1,11 +1,11 @@
 package no.sikt.graphitron.validation.messages;
 
-import no.sikt.graphitron.validation.messages.interfaces.WarningMessage;
+import no.sikt.graphitron.validation.messages.interfaces.ErrorMessage;
 
 import static no.sikt.graphql.directives.GenerationDirective.RECORD;
 import static no.sikt.graphql.directives.GenerationDirective.TABLE;
 
-public enum InputDirectiveWarning implements WarningMessage {
+public enum InputDirectiveError implements ErrorMessage {
     RECORD_TYPE_CONFLICT(String.format("Input types can only be mapped to one record category (either a jOOQ record " +
                     "via @%1$s or a Java record via @%2$s), but input type '%%s' has both directives. " +
                     "Remove @%1$s to preserve the existing behaviour.",
@@ -13,7 +13,7 @@ public enum InputDirectiveWarning implements WarningMessage {
 
     private final String msg;
 
-    InputDirectiveWarning(String msg) {
+    InputDirectiveError(String msg) {
         this.msg = msg;
     }
 

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InputDirectiveValidationTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/validation/InputDirectiveValidationTest.java
@@ -15,10 +15,10 @@ public class InputDirectiveValidationTest extends ValidationTest {
     }
 
     @Test
-    @DisplayName("Input with both @table and @record should log warning")
+    @DisplayName("Input with both @table and @record should throw error")
     void tableAndRecord() {
-        getProcessedSchema("tableAndRecord");
-        assertWarningsContain(
+        assertErrorsContain(
+                "tableAndRecord",
                 String.format(
                         "Input types can only be mapped to one record category (either a jOOQ record via @%1$s or a " +
                                 "Java record via @%2$s), but input type 'TestInput' has both directives. Remove @%1$s to " +


### PR DESCRIPTION
## Overview
**Related issue**: GG-343
**Issue coverage**: closes
**Backwards compatibility**: breaks only invalid usage

## Summary
GraphQL input types in Graphitron schemas previously accepted both `@table` and `@record` directives on the same type, even though an input type can only be mapped to a single record type. A new schema-time validator now rejects this configuration and fails code generation with a message naming the offending input type. Valid schemas are unaffected; only input types that were already misconfigured are now caught at build time.

## Notes
- Builds will now fail for any input type declaring both `@table` and `@record`. Upgraders should grep their schemas for input types carrying both directives and remove whichever was not intended.