### PR TITLE
Return null instead of empty list for null resolver key

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -27,6 +27,7 @@ import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.getGener
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.wrapArrayList;
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
+import static no.sikt.graphitron.javapoet.CodeBlock.ofVar;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
 import static no.sikt.graphitron.mappings.TableReflection.*;
 import static org.apache.commons.lang3.StringUtils.capitalize;
@@ -855,5 +856,23 @@ public class FormatCodeBlocks {
      */
     public static CodeBlock extractKeyAsTableRecord(String variableName, TypeName recordClass) {
         return CodeBlock.of("$N.key().into($T.class)", variableName, recordClass);
+    }
+
+    /**
+     * Same as {@link #extractKeyAsTableRecord} but emits a null-guard so the expression is safe
+     * to evaluate when the source variable may be null at runtime (e.g. when a service returns
+     * null or a list element is null).
+     *
+     * <p>Example output: {@code myTableRecord != null ? myTableRecord.key().into(MyTableRecord.class) : null}
+     *
+     * @param variableName variable name of the table record to extract the key from.
+     * @param recordClass  the record class to map the key into. This should match the record class of the variable.
+     * @return CodeBlock that converts a possibly-null table record into a key-only record, or null.
+     */
+    public static CodeBlock extractKeyAsTableRecordWithNullCheck(String variableName, TypeName recordClass) {
+        return CodeBlock.transformIfNotNull(
+                ofVar(variableName),
+                extractKeyAsTableRecord(variableName, recordClass)
+        );
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
@@ -41,6 +41,7 @@ import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
 import static no.sikt.graphitron.generators.context.NodeIdReferenceHelpers.resolveColumnNamesForNodeIdField;
 import static no.sikt.graphitron.generators.dto.DTOGenerator.getDTOGetterMethodNameForField;
 import static no.sikt.graphitron.javapoet.CodeBlock.declare;
+import static no.sikt.graphitron.javapoet.CodeBlock.ofVar;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.FUNCTION;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.RESOLVER_HELPERS;
 import static no.sikt.graphitron.mappings.TableReflection.getRecordClass;
@@ -238,9 +239,11 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
 
         var isIterable = target.isIterableWrapped();
         var keyVarName = isIterable ? VAR_SERVICE_KEYS : VAR_SERVICE_KEY;
-        var toTableRecord = extractKeyAsTableRecord(isIterable ? VAR_RECORD_ITERATOR : VAR_SERVICE_RESULT, recordClassName);
+        var toTableRecord = extractKeyAsTableRecordWithNullCheck(isIterable ? VAR_RECORD_ITERATOR : VAR_SERVICE_RESULT, recordClassName);
         var keyValue = isIterable
-                ? CodeBlock.of("$N.stream().map($N -> $L)$L", VAR_SERVICE_RESULT, VAR_RECORD_ITERATOR, toTableRecord, collectToList())
+                ? CodeBlock.transformIfNotNull(
+                        ofVar(VAR_SERVICE_RESULT),
+                        CodeBlock.of("$N.stream().map($N -> $L)$L", VAR_SERVICE_RESULT, VAR_RECORD_ITERATOR, toTableRecord, collectToList()))
                 : toTableRecord;
 
         return CodeBlock.builder()

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/datafetchers/services/fetch/ResolverTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/datafetchers/services/fetch/ResolverTest.java
@@ -186,7 +186,7 @@ public class ResolverTest extends GeneratorTest {
     void returningTableWithAutoFetch() {
         assertGeneratedContentContains(
                 "operation/returningTableWithAutoFetch", Set.of(CUSTOMER_TABLE),
-                "_iv_serviceResult.key().into(",
+                "_iv_serviceResult != null ? _iv_serviceResult.key().into(CustomerRecord.class) : null",
                 "new DataFetcherHelper(_iv_env).load(_iv_serviceKey"
         );
     }
@@ -205,7 +205,7 @@ public class ResolverTest extends GeneratorTest {
     void returningTableListWithAutoFetch() {
         assertGeneratedContentContains(
                 "operation/returningTableListWithAutoFetch", Set.of(CUSTOMER_TABLE),
-                "_iv_serviceResult.stream().map(_iv_r -> _iv_r.key().into(",
+                "_iv_serviceResult != null ? _iv_serviceResult.stream().map(_iv_r -> _iv_r != null ? _iv_r.key().into(CustomerRecord.class) : null).toList() : null",
                 "new DataFetcherHelper(_iv_env).loadByResolverKeys(_iv_serviceKeys"
         );
     }

--- a/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/CodeBlock.java
+++ b/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/CodeBlock.java
@@ -171,6 +171,15 @@ public final class CodeBlock {
     }
 
     /**
+     * Null-safe transformation: emits {@code codeToCheck != null ? thenExpr : null}.
+     * <p>Use when {@code codeToCheck} may be null at runtime and {@code transformExpr} would NPE
+     * on a null source.
+     */
+    public static CodeBlock transformIfNotNull(CodeBlock codeToCheck, CodeBlock transformExpr) {
+        return CodeBlock.of("$L != null ? $L : null", codeToCheck, transformExpr);
+    }
+
+    /**
      * Creates a static method call: {@code Type.method(arg1, arg2, ...)}.
      * Empty arguments are filtered out. The type is emitted as {@code $T} for correct import handling.
      */

--- a/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
@@ -186,16 +186,28 @@ public class DataFetcherHelper extends AbstractFetcher {
         return mergedKeys;
     }
 
+    /**
+     * Load values for a list of resolver keys, preserving order and nulls.
+     *
+     * <p>The DB query is invoked only with the non-null subset of {@code keys}, but the returned
+     * list has the same length as {@code keys}, with {@code null} at every index where {@code keys}
+     * contained {@code null} or where no DB row matched.
+     *
+     * @param keys ordered list of keys; may be {@code null} or contain {@code null} elements.
+     * @param dbFunction function to fetch values for the non-null keys.
+     * @return ordered result list, length-matched to {@code keys}; an empty list when {@code keys}
+     *         is {@code null} or empty.
+     */
     public <K, V> CompletableFuture<List<V>> loadByResolverKeys(List<K> keys, DBQuery<K, V> dbFunction) {
-        keys = keys == null ? List.of() : keys.stream().filter(Objects::nonNull).toList();
-        if (keys.isEmpty()) {
+        if (keys == null || keys.isEmpty()) {
             return CompletableFuture.completedFuture(List.of());
         }
         return loadByKeysOrdered(keys, dbFunction);
     }
 
     private <K, V> CompletableFuture<List<V>> loadByKeysOrdered(List<K> keys, DBQuery<K, V> dbFunction) {
-        var dbResult = dbFunction.callDBMethod(dslContext, new HashSet<>(keys), select);
+        var nonNullKeySet = keys.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        var dbResult = dbFunction.callDBMethod(dslContext, nonNullKeySet, select);
         var orderedResult = keys.stream().map(dbResult::get).toList();
         return CompletableFuture.completedFuture(orderedResult);
     }

--- a/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/DataFetcherHelper.java
@@ -193,13 +193,20 @@ public class DataFetcherHelper extends AbstractFetcher {
      * list has the same length as {@code keys}, with {@code null} at every index where {@code keys}
      * contained {@code null} or where no DB row matched.
      *
+     * <p>{@code null} input and an empty input are distinguished and produce different results: a
+     * {@code null} {@code keys} list yields a completed future of {@code null}, while an empty list
+     * yields a completed future of an empty list. This distinction is preserved into the GraphQL
+     * response.
+     *
      * @param keys ordered list of keys; may be {@code null} or contain {@code null} elements.
      * @param dbFunction function to fetch values for the non-null keys.
      * @return ordered result list, length-matched to {@code keys}; an empty list when {@code keys}
-     *         is {@code null} or empty.
+     *         is empty, and {@code null} when {@code keys} is {@code null}.
      */
     public <K, V> CompletableFuture<List<V>> loadByResolverKeys(List<K> keys, DBQuery<K, V> dbFunction) {
-        if (keys == null || keys.isEmpty()) {
+        if (keys == null) {
+            return CompletableFuture.completedFuture(null);
+        } else if (keys.isEmpty()) {
             return CompletableFuture.completedFuture(List.of());
         }
         return loadByKeysOrdered(keys, dbFunction);

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_null_resolverKey_after_service-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_null_resolverKey_after_service-1.result.approved.json
@@ -3,9 +3,7 @@
         "helloWorldWithNullResolverKeys": [
             {
                 "film": null,
-                "films": [
-                    
-                ]
+                "films": null
             }
         ]
     }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_auto_fetch_null-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_auto_fetch_null-1.result.approved.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "customerServiceReturningNull": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_auto_fetch-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_auto_fetch-1.result.approved.json
@@ -6,6 +6,7 @@
                     "firstName": "MARY"
                 }
             },
+            null,
             {
                 "name": {
                     "firstName": "PATRICIA"

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_empty_list-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_empty_list-1.result.approved.json
@@ -1,0 +1,7 @@
+{
+    "data": {
+        "customerServiceListReturningEmptyList": [
+            
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_null-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_null-1.result.approved.json
@@ -1,0 +1,7 @@
+{
+    "data": {
+        "customerServiceListReturningNull": [
+            
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_null-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_list_returning_null-1.result.approved.json
@@ -1,7 +1,5 @@
 {
     "data": {
-        "customerServiceListReturningNull": [
-            
-        ]
+        "customerServiceListReturningNull": null
     }
 }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_auto_fetch_null.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_auto_fetch_null.graphql
@@ -1,0 +1,6 @@
+# Service with autofetch returning null for the resolver key.
+{
+    customerServiceReturningNull {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_list_returning_empty_list.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_list_returning_empty_list.graphql
@@ -1,0 +1,6 @@
+# Service with autofetch returning an empty list of resolver keys.
+{
+    customerServiceListReturningEmptyList {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_list_returning_null.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_list_returning_null.graphql
@@ -1,0 +1,6 @@
+# Service with autofetch returning null instead of a list of resolver keys.
+{
+    customerServiceListReturningNull {
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/CustomerService.java
@@ -1,12 +1,13 @@
 package no.sikt.graphitron.example.service;
 
 import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
-import no.sikt.graphitron.example.service.records.HelloWorldInput;
 import no.sikt.graphitron.example.service.records.CustomerEmailsRecordPayload;
+import no.sikt.graphitron.example.service.records.HelloWorldInput;
 import no.sikt.graphitron.example.service.records.UpdateCustomerEmailRecord;
 import no.sikt.graphitron.example.service.records.UpdateCustomerEmailResult;
 import org.jooq.DSLContext;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CustomerService {
@@ -25,6 +26,18 @@ public class CustomerService {
         return customer;
     }
 
+    public CustomerRecord customerReturningNull() {
+        return null;
+    }
+
+    public List<CustomerRecord> customersReturningNull() {
+        return null;
+    }
+
+    public List<CustomerRecord> customersReturningEmptyList() {
+        return List.of();
+    }
+
     public CustomerRecord customer(HelloWorldInput input) {
         // In a real scenario, the service would use the input to perform business logic
         // (e.g. look up a customer) and return a record with the PK set.
@@ -40,7 +53,11 @@ public class CustomerService {
         c1.setCustomerId(1);
         var c2 = new CustomerRecord();
         c2.setCustomerId(2);
-        return List.of(c1, c2);
+        var customers = new ArrayList<CustomerRecord>();
+        customers.add(c1);
+        customers.add(null);
+        customers.add(c2);
+        return customers;
     }
 
     public List<CustomerRecord> createCustomerEmail() {

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
@@ -15,9 +15,12 @@ extend type Query {
     helloWorldWithNullResolverKeys: [HelloWorldObject] @service(service: {className: "no.sikt.graphitron.example.service.HelloWorldService"})
 
     customerService: Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
+    customerServiceReturningNull: Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customerReturningNull"})
     customerServiceWithJooqRecordInput(input: CustomerInput!): Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
     customerServiceWithJavaRecordInput(input: HelloWorldInputObject!): Customer @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customer"})
     customerServiceList: [Customer] @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customers"})
+    customerServiceListReturningNull: [Customer] @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customersReturningNull"})
+    customerServiceListReturningEmptyList: [Customer] @service(service: {className: "no.sikt.graphitron.example.service.CustomerService", method: "customersReturningEmptyList"})
 
     mockUpdateAddressAndCustomer: MockUpdateAddressAndCustomerPayload @service(service: {className: "no.sikt.graphitron.example.service.MockService"})
 }


### PR DESCRIPTION
## Overview
**Related issue**: GG-439
**Issue coverage**: related
**Backwards compatibility**: no

## Summary
`DataFetcherHelper.loadByResolverKeys` previously returned `[]` for both `null` key and empty list of keys. It now returns `null` for `null` key and `[]` for empty keys, so the two cases stay distinct.

## Notes
- `loadByResolverKeys` is invoked from generated splitquery resolvers in addition to auto-fetch. Any of those whose key getter returns `null` now produces `null` in the GraphQL response instead of `[]`. The existing `query_null_resolverKey_after_service` approval flipped from `"films": []` to `"films": null` to reflect this.
- Downstream consumer schemas that declare list fields as `[T!]!` may fail GraphQL non-null validation on codepaths that previously produced `[]`.
