### PR TITLE
Add .claude/commands/local to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 CLAUDE.local.md
 thoughts/
 .claude/worktrees/
+.claude/commands/local/
 
 /graphitron-example/graphitron-example-server/.approval_tests**
 /graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/jooq/generated/**


### PR DESCRIPTION
Adds `.claude/commands/local/` to `.gitignore` so contributors can keep personal or draft Claude Code slash commands inside the repo without risking accidental commits. Commands placed there are invoked with the `local:` prefix (e.g. `/local:prepare_for_pr`), while project-wide commands continue to live in `.claude/commands/` and are invoked unprefixed. 