### PR TITLE
fix NodeIdStrategy marking PK fields as untouched

### DIFF
--- a/graphitron-common/src/main/java/no/sikt/graphql/NodeIdStrategy.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/NodeIdStrategy.java
@@ -82,11 +82,14 @@ public class NodeIdStrategy {
         return row(keyColumnFields).in(rows);
     }
 
+    /**
+     * Populates the record's PK columns from an encoded node ID. The PK fields end up
+     * with {@code changed=true}; under jOOQ's default {@code Settings.updatablePrimaryKeys=false}
+     * this has no effect on UPDATE statements, but consumers that flip that setting
+     * will see the PKs in UPDATE SET clauses.
+     */
     public void setId(UpdatableRecordImpl<?> record, String id, String typeId, Field<?>... idFields) {
         setFields(record, id, typeId, idFields);
-
-        Arrays.stream(idFields)
-                .forEach(field -> record.changed(field, false));
     }
 
     public void setReferenceId(UpdatableRecordImpl<?> record, String id, String typeId, Field<?>... idFields) {

--- a/graphitron-common/src/test/java/no/sikt/graphql/NodeIdStrategyTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/NodeIdStrategyTest.java
@@ -49,7 +49,7 @@ class NodeIdStrategyTest {
         assertEquals(1234, vacationDestinationRecord.getDestinationId());
         assertEquals("Norway", vacationDestinationRecord.getCountryName());
 
-        assertFalse(vacationDestinationRecord.changed());
+        assertTrue(vacationDestinationRecord.changed());
     }
 
     @Test
@@ -67,7 +67,7 @@ class NodeIdStrategyTest {
         assertEquals(1234, vacationDestinationRecord.getDestinationId());
         assertEquals("Norway", vacationDestinationRecord.getCountryName());
 
-        assertFalse(vacationDestinationRecord.changed());
+        assertTrue(vacationDestinationRecord.changed());
     }
 
     @Test

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film_actor_via_service-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/mutation_insert_film_actor_via_service-1.result.approved.json
@@ -1,0 +1,7 @@
+{
+    "data": {
+        "insertFilmActorsViaService": {
+            "insertedCount": 1
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_insert_film_actor_via_service.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_insert_film_actor_via_service.graphql
@@ -1,0 +1,5 @@
+mutation InsertFilmActorViaService($in: FilmActorInsertWrapper!) {
+    insertFilmActorsViaService(in: $in) {
+        insertedCount
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_insert_film_actor_via_service.variables.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/mutation_insert_film_actor_via_service.variables.json
@@ -1,0 +1,11 @@
+[
+  {
+    "in": {
+      "filmActors": [
+        {
+          "id": "RmlsbUFjdG9yOjIwMCwxMDAw"
+        }
+      ]
+    }
+  }
+]

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/FilmActorInsertService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/FilmActorInsertService.java
@@ -1,0 +1,22 @@
+package no.sikt.graphitron.example.service;
+
+import no.sikt.graphitron.example.service.records.FilmActorInsertResult;
+import no.sikt.graphitron.example.service.records.FilmActorInsertWrapper;
+import org.jooq.DSLContext;
+
+public class FilmActorInsertService {
+    private final DSLContext ctx;
+
+    public FilmActorInsertService(DSLContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public FilmActorInsertResult insert(FilmActorInsertWrapper wrapper) {
+        int count = 0;
+        for (var record : wrapper.getFilmActors()) {
+            record.attach(ctx.configuration());
+            count += record.insert();
+        }
+        return new FilmActorInsertResult(count);
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/FilmActorInsertResult.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/FilmActorInsertResult.java
@@ -1,0 +1,20 @@
+package no.sikt.graphitron.example.service.records;
+
+public class FilmActorInsertResult {
+    private Integer insertedCount;
+
+    public FilmActorInsertResult() {
+    }
+
+    public FilmActorInsertResult(Integer insertedCount) {
+        this.insertedCount = insertedCount;
+    }
+
+    public Integer getInsertedCount() {
+        return insertedCount;
+    }
+
+    public void setInsertedCount(Integer insertedCount) {
+        this.insertedCount = insertedCount;
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/FilmActorInsertWrapper.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/records/FilmActorInsertWrapper.java
@@ -1,0 +1,20 @@
+package no.sikt.graphitron.example.service.records;
+
+import no.sikt.graphitron.example.generated.jooq.tables.records.FilmActorRecord;
+
+import java.util.List;
+
+public class FilmActorInsertWrapper {
+    private List<FilmActorRecord> filmActors;
+
+    public FilmActorInsertWrapper() {
+    }
+
+    public List<FilmActorRecord> getFilmActors() {
+        return filmActors;
+    }
+
+    public void setFilmActors(List<FilmActorRecord> filmActors) {
+        this.filmActors = filmActors;
+    }
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
@@ -162,6 +162,23 @@ extend type Mutation {
             method: "check"
         }
     )
+
+    """Service-mutation that calls record.insert() directly on a Graphitron-mapped UpdatableRecord, exercising the path where PK fields come from the input nodeId."""
+    insertFilmActorsViaService(in: FilmActorInsertWrapper!)
+    : FilmActorInsertResult @service(
+        service: {
+            className: "no.sikt.graphitron.example.service.FilmActorInsertService",
+            method: "insert"
+        }
+    )
+}
+
+input FilmActorInsertWrapper @record(record: {className: "no.sikt.graphitron.example.service.records.FilmActorInsertWrapper"}) {
+    filmActors: [FilmActorValidationInput!]!
+}
+
+type FilmActorInsertResult @record(record: {className: "no.sikt.graphitron.example.service.records.FilmActorInsertResult"}) {
+    insertedCount: Int
 }
 
 type CreateCustomerEmailPayload{


### PR DESCRIPTION
## Overview
**Related issue**: GG-395
**Issue coverage**: closes
**Backwards compatibility**: yes

## Summary
`NodeIdStrategy.setId()` reset PK fields to `changed=false` after populating them, so `record.insert()` and `DSLContext.batchInsert` omitted the PKs and triggered NOT NULL violations. Removing the reset is safe under jOOQ's default `Settings.updatablePrimaryKeys=false`, where `update()` excludes PKs from the SET clause regardless of changed flags; consumers that have flipped that setting will see PKs added to UPDATE SET clauses for `setId`-produced records. A new approval test mirrors the customer reproduction with a custom `@service` resolver calling `record.insert()` directly on a mapped `UpdatableRecord`.

