### PR TITLE
Add apply-style methods to CodeBlock to clean and simplify call chains with wrapping.

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.asListedName;
 import static no.sikt.graphitron.generators.codebuilding.NameFormat.recordTransformMethod;
@@ -410,32 +411,6 @@ public class FormatCodeBlocks {
     }
 
     /**
-     * @return CodeBlock that wraps the provided CodeBlock in a for loop.
-     */
-    @NotNull
-    public static CodeBlock wrapFor(String variable, CodeBlock code) {
-        return CodeBlock
-                .builder()
-                .beginControlFlow("for (var $L : $N)", namedIteratorPrefix(variable), inputPrefix(variable))
-                .add(code)
-                .endControlFlow()
-                .build();
-    }
-
-    /**
-     * @return CodeBlock that wraps the provided CodeBlock in an indexed for loop.
-     */
-    @NotNull
-    public static CodeBlock wrapForIndexed(String variable, CodeBlock code) {
-        return CodeBlock
-                .builder()
-                .beginControlFlow("for (int $1L = 0; $1N < $2N.size(); $1N++)", namedIndexIteratorPrefix(variable), inputPrefix(variable))
-                .add(code)
-                .endControlFlow()
-                .build();
-    }
-
-    /**
      * @return CodeBlock that wraps the provided CodeBlock in a jOOQ row.
      */
     @NotNull
@@ -465,6 +440,64 @@ public class FormatCodeBlocks {
     @NotNull
     public static CodeBlock wrapSelectIfRequested(String path, CodeBlock code) {
         return CodeBlock.of("$N.ifRequested($S, () -> $L)", VAR_SELECT, path, indentIfMultiline(code));
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in a {@code for}-each loop over the named variable.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapFor(String variable) {
+        return b -> CodeBlock
+                .builder()
+                .beginControlFlow("for (var $L : $N)", namedIteratorPrefix(variable), inputPrefix(variable))
+                .add(b.build())
+                .endControlFlow();
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in an indexed {@code for} loop.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapForIndexed(String variable) {
+        return b -> CodeBlock
+                .builder()
+                .beginControlFlow("for (int $1L = 0; $1N < $2N.size(); $1N++)", namedIndexIteratorPrefix(variable), inputPrefix(variable))
+                .add(b.build())
+                .endControlFlow();
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in {@code DSL.row(...)}. Returns an empty builder
+     * when the receiver is empty (matches {@link #wrapRow(CodeBlock)} behavior).
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapRow() {
+        return b -> {
+            var inner = b.build();
+            if (inner.isEmpty()) return CodeBlock.builder();
+            return CodeBlock.builder().add("$T.row($L)", DSL.className, indentIfMultiline(inner));
+        };
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in {@code QueryHelper.rowOfMap(...)}. Returns an
+     * empty builder when the receiver is empty.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapRowOfMap() {
+        return b -> {
+            var inner = b.build();
+            if (inner.isEmpty()) return CodeBlock.builder();
+            return CodeBlock.builder().add("$T.rowOfMap($L)", QUERY_HELPER.className, indentIfMultiline(inner));
+        };
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in {@code DSL.coalesce(...)}. Returns an empty
+     * builder when the receiver is empty.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapCoalesce() {
+        return b -> {
+            var inner = b.build();
+            if (inner.isEmpty()) return CodeBlock.builder();
+            return CodeBlock.builder().add("$T.coalesce($L)", DSL.className, indentIfMultiline(inner));
+        };
     }
 
     /**

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/MapperContext.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/context/MapperContext.java
@@ -8,6 +8,7 @@ import no.sikt.graphitron.generators.codebuilding.FormatCodeBlocks;
 import no.sikt.graphitron.javapoet.ClassName;
 import no.sikt.graphitron.javapoet.CodeBlock;
 import no.sikt.graphitron.javapoet.ParameterizedTypeName;
+import no.sikt.graphitron.javapoet.Wrappers;
 import no.sikt.graphql.schema.ProcessedSchema;
 import org.jetbrains.annotations.Nullable;
 
@@ -349,29 +350,28 @@ public class MapperContext {
                 .add(fieldCode);
 
         if (createsDataFetchers) {
-            return isIterable ? wrapForIndexed(sourceName, code.build()) : code.build();
+            return code.applyIf(isIterable, wrapForIndexed(sourceName)).build();
         }
 
         if (hasSourceName()) {
             if (!isValidation && isIterable && (!mapsJavaRecord || hasRecordReference)) {
-                code.add(CodeBlock.statementOf("$N.add($N)", listedOutputPrefix(targetName), outputPrefix(targetName)));
+                code.addStatement("$N.add($N)", listedOutputPrefix(targetName), outputPrefix(targetName));
             } else if (isValidation && previousContext.isInitContext) {
                 code.addStatement("$N.addAll($T.validatePropertiesAndGenerateGraphQLErrors($N, $N, $N))", VAR_VALIDATION_ERRORS, RECORD_VALIDATOR.className, namedIteratorPrefixIf(sourceName, isIterable), VAR_PATHS_FOR_PROPERTIES, VAR_ENV);
             }
         }
 
-        var forCode = CodeBlock.builder().add(isIterable && hasSourceName() ? (isValidation || toRecord ? wrapForIndexed(sourceName, code.build()) : wrapFor(sourceName, code.build())) : code.build());
+        code.applyIf(isIterable && hasSourceName(), isValidation || toRecord ? wrapForIndexed(sourceName) : wrapFor(sourceName));
         if (isValidation || !previousContext.isInitContext && (toRecord || !mapsJavaRecord)) {
-            return forCode.build();
+            return code.build();
         }
 
         if (!previousContext.isInitContext) {
-            return forCode.add(getSetMappingBlock(outputPrefix(targetName))).build();
+            return code.add(getSetMappingBlock(outputPrefix(targetName))).build();
         }
 
-        return CodeBlock
-                .builder()
-                .add(hasSourceName() ? wrapNotNull(inputPrefix(sourceName), forCode.build()) : forCode.build())
+        return code
+                .applyIf(hasSourceName(), Wrappers.wrapNotNull(inputPrefix(sourceName)))
                 .addIf(toRecord && !mapsJavaRecord, () -> applyGlobalTransforms(targetName, targetType.getRecordClassName(), TransformScope.ALL_MUTATIONS)) // Note: This is done after records are filled.
                 .build();
     }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/datafetchers/operations/OperationMethodGenerator.java
@@ -19,10 +19,7 @@ import no.sikt.graphitron.generators.codeinterface.wiring.WiringContainer;
 import no.sikt.graphitron.generators.context.InputParser;
 import no.sikt.graphitron.generators.context.MapperContext;
 import no.sikt.graphitron.generators.db.FetchTableRecordDBMethodGenerator;
-import no.sikt.graphitron.javapoet.CodeBlock;
-import no.sikt.graphitron.javapoet.CodeBlocks;
-import no.sikt.graphitron.javapoet.MethodSpec;
-import no.sikt.graphitron.javapoet.TypeName;
+import no.sikt.graphitron.javapoet.*;
 import no.sikt.graphql.GraphitronContext;
 import no.sikt.graphql.schema.ProcessedSchema;
 
@@ -592,7 +589,7 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
         if (context.hasTable() && !context.isTopLevelContext()) {
             var record = context.transformInputRecord();
             if (!context.getPreviousContext().wasIterable()) {
-                code.addStatement("$L = $L", inputPrefix(asListedRecordNameIf(sourceName, context.isIterable())), record);
+                code.assign(inputPrefix(asListedRecordNameIf(sourceName, context.isIterable())), record);
             } else {
                 code.addStatement("$N.add$L($L)", inputPrefix(asListedRecordName(sourceName)), context.isIterable() ? "All" : "", record);
             }
@@ -607,7 +604,10 @@ public class OperationMethodGenerator extends DataFetcherMethodGenerator {
             return code.build();
         }
 
-        return wrapNotNull(inputPrefix(sourceName), code.add(context.wrapFields(fieldCode.build())).build());
+        return code
+                .add(context.wrapFields(fieldCode.build()))
+                .apply(Wrappers.wrapNotNull(inputPrefix(sourceName)))
+                .build();
     }
 
     private CodeBlock declareContextArgs(ObjectField target) {

--- a/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/CodeBlock.java
+++ b/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/CodeBlock.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -1116,6 +1117,33 @@ public final class CodeBlock {
             formatParts.clear();
             args.clear();
             return this;
+        }
+
+        /**
+         * Applies a transform to this builder. Allows keeping a fluent chain intact when
+         * wrapping the accumulated content in additional code (e.g. an {@code if} guard,
+         * a {@code for} loop, or a {@code DSL.row(...)} call).
+         *
+         * <p>If the transform returns a different builder, its contents are folded back
+         * into this builder so the receiver always reflects the transformed state.
+         */
+        public Builder apply(UnaryOperator<Builder> transform) {
+            Builder result = transform.apply(this);
+            if (result != this) {
+                CodeBlock built = result.build();
+                clear();
+                formatParts.addAll(built.formatParts());
+                args.addAll(built.args());
+            }
+            return this;
+        }
+
+        /**
+         * Conditional variant of {@link #apply(UnaryOperator)}: runs the transform only when
+         * {@code predicate} is {@code true}, otherwise returns this builder unchanged.
+         */
+        public Builder applyIf(boolean predicate, UnaryOperator<Builder> transform) {
+            return predicate ? apply(transform) : this;
         }
 
         public CodeBlock build() {

--- a/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/Wrappers.java
+++ b/graphitron-codegen-parent/graphitron-javapoet/src/main/java/no/sikt/graphitron/javapoet/Wrappers.java
@@ -1,0 +1,23 @@
+package no.sikt.graphitron.javapoet;
+
+import java.util.function.UnaryOperator;
+
+public class Wrappers {
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in {@code if (conditionValue != null) { ... }}.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapNotNull(String conditionValue) {
+        return wrapNotNull(CodeBlock.ofVar(conditionValue));
+    }
+
+    /**
+     * returns a transform that wraps the receiver builder's accumulated content in {@code if (conditionValue != null) { ... }}.
+     */
+    public static UnaryOperator<CodeBlock.Builder> wrapNotNull(CodeBlock conditionValue) {
+        return b -> CodeBlock
+                .builder()
+                .beginControlFlow("if ($L != null)", conditionValue)
+                .add(b.build())
+                .endControlFlow();
+    }
+}

--- a/graphitron-codegen-parent/graphitron-javapoet/src/test/java/no/sikt/graphitron/javapoet/CodeBlockTest.java
+++ b/graphitron-codegen-parent/graphitron-javapoet/src/test/java/no/sikt/graphitron/javapoet/CodeBlockTest.java
@@ -580,4 +580,71 @@ public final class CodeBlockTest {
                 .build();
         assertThat(block.toString()).isEqualTo("x = a + b;\n");
     }
+
+    // --- apply / applyIf ---
+
+    @Test
+    public void applyRunsTheTransform() {
+        CodeBlock result = CodeBlock
+                .builder()
+                .add("inner")
+                .apply(b -> CodeBlock.builder().add("wrap($L)", b.build()))
+                .build();
+        assertThat(result.toString()).isEqualTo("wrap(inner)");
+    }
+
+    @Test
+    public void applyPreservesChain() {
+        CodeBlock result = CodeBlock
+                .builder()
+                .add("a")
+                .apply(b -> CodeBlock.builder().add("[$L]", b.build()))
+                .add("b")
+                .build();
+        assertThat(result.toString()).isEqualTo("[a]b");
+    }
+
+    @Test
+    public void applyIfTrueRunsTransform() {
+        CodeBlock result = CodeBlock
+                .builder()
+                .add("x")
+                .applyIf(true, b -> CodeBlock.builder().add("($L)", b.build()))
+                .build();
+        assertThat(result.toString()).isEqualTo("(x)");
+    }
+
+    @Test
+    public void applyIfFalseIsIdentity() {
+        CodeBlock result = CodeBlock
+                .builder()
+                .add("x")
+                .applyIf(false, b -> CodeBlock.builder().add("($L)", b.build()))
+                .build();
+        assertThat(result.toString()).isEqualTo("x");
+    }
+
+    @Test
+    public void applyFoldsTransformResultBackIntoReceiver() {
+        CodeBlock.Builder builder = CodeBlock.builder().add("x");
+        CodeBlock.Builder returned = builder.apply(b -> CodeBlock.builder().add("($L)", b.build()));
+        assertThat(returned).isSameAs(builder);
+        assertThat(builder.build().toString()).isEqualTo("(x)");
+    }
+
+    @Test
+    public void applyIfTrueFoldsResultBackIntoReceiver() {
+        CodeBlock.Builder builder = CodeBlock.builder().add("x");
+        CodeBlock.Builder returned = builder.applyIf(true, b -> CodeBlock.builder().add("($L)", b.build()));
+        assertThat(returned).isSameAs(builder);
+        assertThat(builder.build().toString()).isEqualTo("(x)");
+    }
+
+    @Test
+    public void applyIfFalseLeavesReceiverUnchanged() {
+        CodeBlock.Builder builder = CodeBlock.builder().add("x");
+        CodeBlock.Builder returned = builder.applyIf(false, b -> CodeBlock.builder().add("($L)", b.build()));
+        assertThat(returned).isSameAs(builder);
+        assertThat(builder.build().toString()).isEqualTo("x");
+    }
 }


### PR DESCRIPTION
This is just a trivial visual improvement, split to this PR to not pollute other PRs. Includes a few examples of how it looks with apply.