### PR TITLE
GG-449 Run approval tests against codegen config variants

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -13,10 +13,19 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            mvn-args: verify javadoc:javadoc
+          - name: variant-upsert-as-merge
+            mvn-args: -Pvariant-upsert-as-merge verify -pl :graphitron-example-server -am -Dtest=ApprovalQueryTest -Dsurefire.failIfNoSpecifiedTests=false
+          - name: variant-jdbc-batching
+            mvn-args: -Pvariant-jdbc-batching verify -pl :graphitron-example-server -am -Dtest=ApprovalQueryTest -Dsurefire.failIfNoSpecifiedTests=false
+    name: ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v6
     - name: Set up JDK 21
@@ -26,4 +35,12 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn --batch-mode verify javadoc:javadoc --file pom.xml
+      run: mvn --batch-mode ${{ matrix.mvn-args }} --file pom.xml
+
+  # Aggregator job so the required `build` status check (configured in branch
+  # protection) reports a single result after all matrix entries finish.
+  build:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All matrix entries succeeded"

--- a/.mise.toml
+++ b/.mise.toml
@@ -45,3 +45,14 @@ sources = ["graphitron-example/graphitron-example-spec/src/main/resources/graphq
 [tasks.debug-generate]
 description = "Debug generate for graphitron-example"
 run = "mvnDebug install -pl :graphitron-example-spec"
+
+[tasks.test-variant]
+description = "Run ApprovalQueryTest against a codegen variant. Takes variant name (matches a 'variant-<name>' Maven profile in graphitron-example/pom.xml). Example: 'mise r test-variant upsert-as-merge'."
+run = "mvn -Pvariant-{{arg(index=0)}} verify -pl :graphitron-example-server -am -Dtest=ApprovalQueryTest -Dsurefire.failIfNoSpecifiedTests=false"
+
+[tasks.test-variants]
+description = "Run example-server tests against all known codegen variants."
+run = [
+  "mise r test-variant upsert-as-merge",
+  "mise r test-variant jdbc-batching",
+]

--- a/graphitron-example/README.md
+++ b/graphitron-example/README.md
@@ -6,7 +6,7 @@ The `graphitron-example-server` is a Quarkus application that runs a GraphQL ser
 [Integration tests](#Integration-tests) are included to ensure that Graphitron generates resolvers that work as expected. 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc (https://github.com/thlorenz/doctoc) TO UPDATE -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
 - [Requirements](#requirements)
@@ -18,6 +18,7 @@ The `graphitron-example-server` is a Quarkus application that runs a GraphQL ser
   - [graphitron-example-server](#graphitron-example-server)
   - [graphitron-example-service](#graphitron-example-service)
 - [Integration tests](#integration-tests)
+  - [Running approval tests against codegen variants](#running-approval-tests-against-codegen-variants)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -91,3 +92,22 @@ There are two types of tests:
  - **Match** - these tests are more flexible and can be used to verify the results of a query against a custom matcher, e.g. hamcrest. 
 
 The tests use the Quarkus test framework which automatically starts the server before running the tests.
+
+### Running approval tests against codegen variants
+The default codegen configuration is defined as properties in [`graphitron-example/pom.xml`](pom.xml). Variant profiles in the same pom override individual flags. Variant runs rebuild the spec module with the override and execute `ApprovalQueryTest` against the variant. Defined variants:
+
+- `upsert-as-merge` — `generateUpsertAsStore=false` (emits `batchMerge` instead of `batchStore`).
+- `jdbc-batching` — `useJdbcBatchingForDeletes=true` and `useJdbcBatchingForInserts=true`. Emits `batchDelete` and `batchInsert` instead of direct insert and delete statements.
+
+Approved files for a variant live under `graphitron-example-server/src/test/resources/approval/approvals/variants/<variant>/`. The `ApprovalQueryTest` looks up an approved file there first and falls back to the default approvals directory, so the variant directory only needs to contain the queries whose output actually differs from the default.
+
+Mise tasks:
+```sh
+mise r test-variant upsert-as-merge   # run a single variant
+mise r test-variants                  # run all known variants
+```
+
+To add a new variant:
+1. Add a `<profile>` to `graphitron-example/pom.xml` that sets `approval.variant` and overrides the relevant `graphitron.*` properties.
+2. Add the profile id to the matrix in `.github/workflows/maven-build.yml` and to the `test-variants` task in [`.mise.toml`](../.mise.toml).
+3. Run `mise r test-variant <your-variant>` locally; promote any divergent `.received.json` files in the variant directory to `.approved.json`.

--- a/graphitron-example/graphitron-example-server/pom.xml
+++ b/graphitron-example/graphitron-example-server/pom.xml
@@ -140,6 +140,7 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <approval.variant>${approval.variant}</approval.variant>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/graphitron-example/graphitron-example-server/src/test/java/no/sikt/graphitron/example/server/approval/ApprovalQueryTest.java
+++ b/graphitron-example/graphitron-example-server/src/test/java/no/sikt/graphitron/example/server/approval/ApprovalQueryTest.java
@@ -10,12 +10,13 @@ import io.restassured.http.Headers;
 import jakarta.json.Json;
 import jakarta.json.JsonString;
 import org.approvaltests.core.Options;
-import org.approvaltests.namer.NamerWrapper;
+import org.approvaltests.namer.ApprovalNamer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -34,16 +35,24 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.approvaltests.Approvals.verify;
 
-/***
- * Runs all queries found under resources/approval/queries
- * and compares with previously verified results found under resources/approval/approvals.
- * To pass the test, the query must return the same result as the previously verified result.
+/**
+ * Runs all queries found under resources/approval/queries and compares each response
+ * to a previously verified result. With no {@code -Dapproval.variant} system property,
+ * results are read from resources/approval/approvals. With a variant active, results
+ * are read from resources/approval/approvals/variants/&lt;variant&gt;/ first, falling back
+ * to the default approvals directory when the variant has no override for that query.
  */
 @QuarkusTest
 public class ApprovalQueryTest {
 
     private static final Path QUERY_FILE_DIRECTORY = Paths.get("src", "test", "resources", "approval", "queries");
-    private static final Path APPROVALS_FILE_DIRECTORY = Paths.get("src", "test", "resources", "approval", "approvals");
+    private static final Path APPROVALS_BASE = Paths.get("src", "test", "resources", "approval", "approvals");
+    private static final String VARIANT = System.getProperty("approval.variant", "");
+    private static final Path VARIANT_OVERRIDES = VARIANT.isBlank() ? null : APPROVALS_BASE.resolve("variants").resolve(VARIANT);
+
+    private static Path activeDirectory() {
+        return VARIANT_OVERRIDES != null ? VARIANT_OVERRIDES : APPROVALS_BASE;
+    }
 
     private static final Pattern UUID_PATTERN = Pattern.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}");
 
@@ -61,12 +70,56 @@ public class ApprovalQueryTest {
                 .body()
                 .asPrettyString();
 
+        var approvalName = queryFile.replace(".graphql", "-" + variableIdx + ".result");
         verify(response, new Options()
                 .withScrubber(str -> UUID_PATTERN.matcher(str).replaceAll("[UUID]"))
-                .forFile().withNamer(new NamerWrapper(
-                        () -> queryFile.replace(".graphql", "-" + variableIdx + ".result"),
-                        APPROVALS_FILE_DIRECTORY::toString))
+                .forFile().withNamer(new VariantOverrideNamer(approvalName))
                 .forFile().withExtension(".json"));
+    }
+
+    /**
+     * Approved files are looked up in the variant override directory first, falling back
+     * to the default approvals directory. Received files always land in the variant
+     * override directory (or the default directory when no variant is active), so accepting
+     * a divergent result is a simple .received -> .approved rename in place.
+     */
+    private record VariantOverrideNamer(String approvalName) implements ApprovalNamer {
+
+        @Override
+        public File getApprovedFile(String extensionWithDot) {
+            if (VARIANT_OVERRIDES != null) {
+                var override = VARIANT_OVERRIDES.resolve(approvalName + ".approved" + extensionWithDot).toFile();
+                if (override.exists()) {
+                    return override;
+                }
+            }
+            return APPROVALS_BASE.resolve(approvalName + ".approved" + extensionWithDot).toFile();
+        }
+
+        @Override
+        public File getReceivedFile(String extensionWithDot) {
+            return activeDirectory().resolve(approvalName + ".received" + extensionWithDot).toFile();
+        }
+
+        @Override
+        public String getApprovalName() {
+            return approvalName;
+        }
+
+        @Override
+        public String getSourceFilePath() {
+            return activeDirectory().toString();
+        }
+
+        @Override
+        public ApprovalNamer addAdditionalInformation(String info) {
+            return this;
+        }
+
+        @Override
+        public String getAdditionalInformation() {
+            return "";
+        }
     }
 
     private static Stream<Arguments> queryFiles() throws IOException {

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film-1.result.approved.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "insertFilm": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_actor_overlap-2.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_actor_overlap-2.result.approved.json
@@ -1,0 +1,22 @@
+{
+    "errors": [
+        {
+            "message": "An exception occurred. The error has been logged with id [UUID]: Required field cannot be empty",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "path": [
+                "insertFilmActor"
+            ],
+            "extensions": {
+                "classification": "DataFetchingException"
+            }
+        }
+    ],
+    "data": {
+        "insertFilmActor": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_wrapped_null_vs_absent-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_wrapped_null_vs_absent-1.result.approved.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "insertFilmWrapped": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_wrapped_null_vs_absent-2.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_film_wrapped_null_vs_absent-2.result.approved.json
@@ -1,0 +1,5 @@
+{
+    "data": {
+        "insertFilmWrapped": null
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_films-2.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_films-2.result.approved.json
@@ -1,0 +1,7 @@
+{
+    "data": {
+        "insertFilms": [
+            
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_films_wrapped_null_vs_absent-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/variants/jdbc-batching/mutation_insert_films_wrapped_null_vs_absent-1.result.approved.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "insertFilmsWrapped": {
+            "films": [
+                
+            ]
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-spec/pom.xml
+++ b/graphitron-example/graphitron-example-spec/pom.xml
@@ -83,17 +83,17 @@
                                 <externalReferenceImport>no.sikt.graphitron.example.service.CustomerWithExternalFields</externalReferenceImport>
                             </externalReferenceImports>
                             <makeNodeStrategy>true</makeNodeStrategy>
-                            <generateUpsertAsStore>true</generateUpsertAsStore>
+                            <generateUpsertAsStore>${graphitron.generateUpsertAsStore}</generateUpsertAsStore>
                             <scalars>
                                 <class>
                                     <fullyQualifiedClassName>no.sikt.graphitron.example.service.ConsumerProvidedScalars</fullyQualifiedClassName>
                                 </class>
                             </scalars>
-                            <useJdbcBatchingForDeletes>false</useJdbcBatchingForDeletes>
-                            <useJdbcBatchingForInserts>false</useJdbcBatchingForInserts>
+                            <useJdbcBatchingForDeletes>${graphitron.useJdbcBatchingForDeletes}</useJdbcBatchingForDeletes>
+                            <useJdbcBatchingForInserts>${graphitron.useJdbcBatchingForInserts}</useJdbcBatchingForInserts>
                             <optionalSelect>
-                                <onSubqueryReferences>true</onSubqueryReferences>
-                                <onExternalFields>true</onExternalFields>
+                                <onSubqueryReferences>${graphitron.optionalSelect.onSubqueryReferences}</onSubqueryReferences>
+                                <onExternalFields>${graphitron.optionalSelect.onExternalFields}</onExternalFields>
                             </optionalSelect>
                         </configuration>
                     </execution>

--- a/graphitron-example/pom.xml
+++ b/graphitron-example/pom.xml
@@ -23,7 +23,32 @@
     <properties>
         <generatedCodePackage>no.sikt.graphitron.example.generated</generatedCodePackage>
         <generatedJooqPackage>${generatedCodePackage}.jooq</generatedJooqPackage>
+
+        <!-- Codegen variant flags. Defaults reflect the canonical configuration; profiles below override them. -->
+        <graphitron.generateUpsertAsStore>true</graphitron.generateUpsertAsStore>
+        <graphitron.useJdbcBatchingForDeletes>false</graphitron.useJdbcBatchingForDeletes>
+        <graphitron.useJdbcBatchingForInserts>false</graphitron.useJdbcBatchingForInserts>
+        <graphitron.optionalSelect.onSubqueryReferences>true</graphitron.optionalSelect.onSubqueryReferences>
+        <graphitron.optionalSelect.onExternalFields>true</graphitron.optionalSelect.onExternalFields>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>variant-upsert-as-merge</id>
+            <properties>
+                <approval.variant>upsert-as-merge</approval.variant>
+                <graphitron.generateUpsertAsStore>false</graphitron.generateUpsertAsStore>
+            </properties>
+        </profile>
+        <profile>
+            <id>variant-jdbc-batching</id>
+            <properties>
+                <approval.variant>jdbc-batching</approval.variant>
+                <graphitron.useJdbcBatchingForDeletes>true</graphitron.useJdbcBatchingForDeletes>
+                <graphitron.useJdbcBatchingForInserts>true</graphitron.useJdbcBatchingForInserts>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
## Overview
**Related issue**: GG-449
**Issue coverage**: closes
**Backwards compatibility**: yes

## Summary
The change adds the ability to run the `graphitron-example-server` approval suite against alternative codegen 
configurations. Variant profiles in the example parent pom override individual `graphitron-maven-plugin` flags;
surefire forwards the active variant name into the test JVM, and `ApprovalQueryTest` looks up approved files
in a per-variant override directory before falling back to the canonical approvals. 

Two variants are wired up: 
 - `upsert-as-merge` (`generateUpsertAsStore=false`) 
   - exercises the `batchMerge` codegen path and currently has no payload divergence
 - `jdbc-batching` (both `useJdbcBatchingForDeletes` and `useJdbcBatchingForInserts` set to `true`) 
   - locks in six divergent approvals corresponding to the documented limitation that insert mutations under JDBC batching cannot return the mutated record

CI runs default plus both variants in a single matrix job, and `mise r test-variant <name>` runs them locally.
Variant runs are scoped to `ApprovalQueryTest` because match-style tests with hardcoded Hamcrest assertions cannot be redirected through the variant approvals folder.
