### PR TITLE
GG-430 support mapping node IDs to table record for query conditions

### DIFF
--- a/graphitron-codegen-parent/graphitron-java-codegen/README.md
+++ b/graphitron-codegen-parent/graphitron-java-codegen/README.md
@@ -26,6 +26,7 @@ using Java and [jOOQ](https://www.jooq.org/).
     - [Skip DataFetcher generation with @notGenerated](#skip-datafetcher-generation-with-notgenerated)
     - [Map fields to table columns with @field](#map-fields-to-table-columns-with-field)
     - [Construct nested types from table columns with @experimental_constructType](#construct-nested-types-from-table-columns-with-experimental_constructtype)
+    - [Resolve fields from database functions with @experimental_procedureCall](#resolve-fields-from-database-functions-with-experimental_procedurecall)
   - [Tables, joins and records](#tables-joins-and-records)
     - [Link types to database tables with @table](#link-types-to-database-tables-with-table)
     - [Define table join paths with @reference](#define-table-join-paths-with-reference)
@@ -43,6 +44,7 @@ using Java and [jOOQ](https://www.jooq.org/).
     - [Example: Condition using nested record configurations](#example-condition-using-nested-record-configurations)
     - [Example: Schema with listed input types and condition set _on_ listed input field](#example-schema-with-listed-input-types-and-condition-set-on-listed-input-field)
     - [Example: Schema with listed input types and condition set on input field _inside_ a list input](#example-schema-with-listed-input-types-and-condition-set-on-input-field-inside-a-list-input)
+    - [Example: Condition with @nodeId argument](#example-condition-with-nodeid-argument)
   - [Map enums with @enum](#map-enums-with-enum)
   - [Generate mutations with @mutation](#generate-mutations-with-mutation)
   - [Custom logic with @service](#custom-logic-with-service)
@@ -53,6 +55,10 @@ using Java and [jOOQ](https://www.jooq.org/).
     - [Auto-fetching @table types from database](#auto-fetching-table-types-from-database)
     - [Nested input structures](#nested-input-structures)
     - [Input types with Java records](#input-types-with-java-records)
+    - [Explicit null vs not provided in services](#explicit-null-vs-not-provided-in-services)
+      - [jOOQ record inputs](#jooq-record-inputs)
+      - [Java record inputs (experimental)](#java-record-inputs-experimental)
+      - [How to use](#how-to-use)
     - [Context variables](#context-variables)
     - [Response mapping](#response-mapping)
   - [Custom table resolution with @tableMethod](#custom-table-resolution-with-tablemethod)
@@ -879,6 +885,26 @@ _Resulting_code_:
                ).toList()
        ) : DSL.noCondition()
 )
+```
+
+#### Example: Condition with @nodeId argument
+A `@nodeId` argument can be received as a decoded jOOQ record by declaring the corresponding
+condition method parameter as the record type.
+
+_Schema_:
+```graphql
+customerWithNextCustomerId(
+    customerId: ID!
+        @nodeId(typeName: "Customer")
+        @condition(condition: {className: "some.path.CustomerConditions", method: "customerWithNextCustomerId"}, override: true)
+): Customer
+```
+
+_Condition method_:
+```java
+public static Condition customerWithNextCustomerId(Customer customer, CustomerRecord id) {
+    return customer.CUSTOMER_ID.eq(id.getCustomerId() + 1);
+}
 ```
 
 ### Map enums with @enum

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/helpers/NodeConfiguration.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/definitions/helpers/NodeConfiguration.java
@@ -68,6 +68,14 @@ public record NodeConfiguration(String typeId, JOOQMapping targetTable, List<Str
     }
 
     /**
+     * @return CodeBlock with comma-separated node ID fields referencing the static table field directly.
+     * Example: {@code FILM.FILM_ID, FILM.TITLE}
+     */
+    public CodeBlock nodeIdFieldsWithStaticFieldBlock() {
+        return tableFieldsBlock(CodeBlock.of("$N", targetTable().getName()), keyColumnsJavaNames());
+    }
+
+    /**
      * @return CodeBlock with comma-separated node ID fields using a table alias variable.
      * Example: {@code _a_film.FILM_ID, _a_film.TITLE}
      */

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/codebuilding/FormatCodeBlocks.java
@@ -861,6 +861,30 @@ public class FormatCodeBlocks {
     }
 
     /**
+     * @return CodeBlock that decodes a single node ID into a table record using
+     * {@link no.sikt.graphql.NodeIdStrategy#nodeIdToTableRecord}.
+     */
+    public static CodeBlock nodeIdToTableRecordBlock(NodeConfiguration node, CodeBlock idValue) {
+        return CodeBlock.of("$N.nodeIdToTableRecord($L, $S, $L)",
+                VAR_NODE_STRATEGY,
+                idValue,
+                node.typeId(),
+                listOf(node.nodeIdFieldsWithStaticFieldBlock())
+        );
+    }
+
+    /**
+     * @return CodeBlock that streams a list of node IDs and decodes each to a table record.
+     */
+    public static CodeBlock nodeIdsToTableRecordsBlock(NodeConfiguration node, CodeBlock listValue) {
+        return CodeBlock.of("$L.stream().map($N -> $L).toList()",
+                listValue,
+                VAR_ITERATOR,
+                nodeIdToTableRecordBlock(node, CodeBlock.of("$N", VAR_ITERATOR))
+        );
+    }
+
+    /**
      * @return CodeBlock with comma-separated table fields using a static table instance resolved from the table name.
      * Example: {@code Film.FILM.FILM_ID, Film.FILM.LANGUAGE_ID}
      */

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/generators/db/FetchDBMethodGenerator.java
@@ -12,6 +12,7 @@ import no.sikt.graphitron.definitions.mapping.JOOQMapping;
 import no.sikt.graphitron.definitions.mapping.MethodMapping;
 import no.sikt.graphitron.definitions.objects.InterfaceDefinition;
 import no.sikt.graphitron.definitions.objects.ObjectDefinition;
+import no.sikt.graphitron.definitions.sql.SQLCondition;
 import no.sikt.graphitron.definitions.sql.SQLJoinStatement;
 import no.sikt.graphitron.generators.abstractions.DBMethodGenerator;
 import no.sikt.graphitron.generators.codebuilding.KeyWrapper;
@@ -28,6 +29,7 @@ import org.jooq.Named;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static no.sikt.graphitron.configuration.GeneratorConfig.*;
@@ -39,14 +41,12 @@ import static no.sikt.graphitron.generators.codebuilding.NameFormat.*;
 import static no.sikt.graphitron.generators.codebuilding.TypeNameFormat.*;
 import static no.sikt.graphitron.generators.codebuilding.VariableNames.*;
 import static no.sikt.graphitron.generators.codebuilding.VariablePrefix.*;
-import static no.sikt.graphitron.generators.dto.DTOGenerator.getDTOGetterMethodNameForField;
 import static no.sikt.graphitron.generators.context.NodeIdReferenceHelpers.isNodeIdReferenceField;
 import static no.sikt.graphitron.generators.context.NodeIdReferenceHelpers.resolveColumnNamesForNodeIdField;
+import static no.sikt.graphitron.generators.dto.DTOGenerator.getDTOGetterMethodNameForField;
 import static no.sikt.graphitron.mappings.JavaPoetClassName.*;
-import static no.sikt.graphitron.mappings.RoutineReflection.getInParameters;
-import static no.sikt.graphitron.mappings.RoutineReflection.getRoutineMethodName;
-import static no.sikt.graphitron.mappings.RoutineReflection.getRoutinesClassName;
-import static no.sikt.graphitron.mappings.RoutineReflection.resolveRoutine;
+import static no.sikt.graphitron.mappings.ReflectionHelpers.methodExpectsTableRecordParamAtIndex;
+import static no.sikt.graphitron.mappings.RoutineReflection.*;
 import static no.sikt.graphitron.mappings.TableReflection.*;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
@@ -808,7 +808,7 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
             }
 
             if (field.hasCondition()) {
-                var conditionInputs = List.of(renderedSequence, getCheckedNameWithPath(inputCondition));
+                var conditionInputs = List.of(renderedSequence, getCheckedNameWithPath(inputCondition, field.getCondition(), 2, 1));
                 allConditionCodeBlocks.add(field.getCondition().formatToString(conditionInputs));
             }
         }
@@ -830,18 +830,22 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
             var sequence = context.iterateJoinSequenceFor(field).render();
 
             if (!sequence.isEmpty() && field.hasCondition()) {
-                var conditionInputs = List.of(sequence, getCheckedNameWithPath(inputCondition));
+                var conditionInputs = List.of(sequence, getCheckedNameWithPath(inputCondition, field.getCondition(), 2, 1));
                 allConditionCodeBlocks.add(field.getCondition().formatToString(conditionInputs));
             }
         }
 
         for (var condition : declaredInputConditions.entrySet()) {
+            var values = condition.getValue();
+            var sqlCondition = condition.getKey().getCondition();
+            var methodInputCount = 1 + values.size();
             var inputs = Stream.concat(
                     Stream.of(context.getCurrentJoinSequence().render()),
-                    condition.getValue().stream().map(this::getCheckedNameWithPath)
+                    IntStream.range(0, values.size())
+                            .mapToObj(i -> getCheckedNameWithPath(values.get(i), sqlCondition, methodInputCount, i + 1))
             ).collect(Collectors.toList());
 
-            allConditionCodeBlocks.add(condition.getKey().getCondition().formatToString(inputs));
+            allConditionCodeBlocks.add(sqlCondition.formatToString(inputs));
         }
         return allConditionCodeBlocks;
     }
@@ -920,20 +924,39 @@ public abstract class FetchDBMethodGenerator extends DBMethodGenerator<ObjectFie
                 .orElseThrow(() -> new IllegalStateException("No join fields found for EXISTS correlation on " + aliasName));
     }
 
-    private CodeBlock getCheckedNameWithPath(InputCondition condition) {
+    private CodeBlock getCheckedNameWithPath(InputCondition condition, SQLCondition sqlCondition, int methodInputCount, int paramIndex) {
         var nameWithPath = condition.getNameWithPath();
         var checks = condition.getChecksAsSequence();
-        var enumConverter = toGraphEnumConverter(
-                condition.getInput().getTypeName(),
-                nameWithPath,
-                true,
-                processedSchema
-        );
+        var input = condition.getInput();
+        var enumConverter = toGraphEnumConverter(input.getTypeName(), nameWithPath, true, processedSchema);
+
+        CodeBlock value;
+        if (!enumConverter.isEmpty()) {
+            value = enumConverter;
+        } else if (processedSchema.isNodeIdField(input)
+                && expectsRecordParam(sqlCondition, methodInputCount, paramIndex)) {
+            var node = processedSchema.getNodeConfigurationForNodeIdFieldOrThrow(input);
+            value = input.isIterableWrapped()
+                    ? nodeIdsToTableRecordsBlock(node, nameWithPath)
+                    : nodeIdToTableRecordBlock(node, nameWithPath);
+        } else {
+            value = nameWithPath;
+        }
 
         return CodeBlock.of(
                 !checks.isEmpty() && !condition.getNamePath().isEmpty() ? checks + " ? $L : null" : "$L",
-                enumConverter.isEmpty() ? nameWithPath : enumConverter
+                value
         );
+    }
+
+    /**
+     * @return whether the condition method's parameter at {@code paramIndex} is a jOOQ table
+     * record (singular or {@code List<…>}).
+     */
+    private static boolean expectsRecordParam(SQLCondition sqlCondition, int methodInputCount, int paramIndex) {
+        return getExternalReferences().getMethodsFrom(sqlCondition.getReference()).stream()
+                .filter(it -> it.getParameterTypes().length == methodInputCount + sqlCondition.getContextFields().size())
+                .anyMatch(method -> methodExpectsTableRecordParamAtIndex(method, paramIndex));
     }
 
     private CodeBlock createTupleCondition(

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/ReflectionHelpers.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/main/java/no/sikt/graphitron/mappings/ReflectionHelpers.java
@@ -85,4 +85,26 @@ public class ReflectionHelpers {
         String targetFieldName = field.getJavaRecordMethodMapping(true).getName();
         return getJooqRecordClassReturnedFromFieldGetter(javaRecordClass, targetFieldName);
     }
+
+    /**
+     * Checks whether the parameter at the given index of {@code method} is a jOOQ table record type —
+     * either an {@link UpdatableRecordImpl} subtype or a {@code List<X>} where {@code X} is one.
+     *
+     * @param method     The method to inspect.
+     * @param paramIndex Zero-based index of the parameter to check.
+     * @return {@code true} if the parameter is a jOOQ table record (singular or listed); {@code false}
+     *         for any other shape (raw types, arrays, {@code Collection}, generic wildcards, etc.).
+     */
+    public static boolean methodExpectsTableRecordParamAtIndex(Method method, int paramIndex) {
+        var raw = method.getParameterTypes()[paramIndex];
+        if (UpdatableRecordImpl.class.isAssignableFrom(raw)) {
+            return true;
+        } else if (!List.class.isAssignableFrom(raw)) {
+            return false;
+        }
+        var generic = method.getGenericParameterTypes()[paramIndex];
+        return generic instanceof ParameterizedType pt
+                && pt.getActualTypeArguments()[0] instanceof Class<?> elt
+                && UpdatableRecordImpl.class.isAssignableFrom(elt);
+    }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/codereferences/conditions/QueryCustomerCondition.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/codereferences/conditions/QueryCustomerCondition.java
@@ -2,6 +2,7 @@ package no.sikt.graphitron.codereferences.conditions;
 
 import no.sikt.graphitron.codereferences.dummyreferences.DummyJOOQEnum;
 import no.sikt.graphitron.jooq.generated.testdata.public_.tables.Customer;
+import no.sikt.graphitron.jooq.generated.testdata.public_.tables.records.CustomerRecord;
 import org.jooq.Condition;
 
 import java.util.List;
@@ -44,6 +45,26 @@ public class QueryCustomerCondition {
     }
 
     public static Condition queryEnumList(Customer c, List<DummyJOOQEnum> e) {
+        return null;
+    }
+
+    public static Condition queryCustomerNodeId(Customer c, CustomerRecord s) {
+        return null;
+    }
+
+    public static Condition queryCustomerIdAndNodeId(Customer c, int customerId, CustomerRecord s) {
+        return null;
+    }
+
+    public static Condition queryCustomerNodeIds(Customer c, List<CustomerRecord> s) {
+        return null;
+    }
+
+    public static Condition queryCustomerNodeIdAsString(Customer c, String s) {
+        return null;
+    }
+
+    public static Condition queryCustomerNodeIdsAsString(Customer c, List<String> s) {
         return null;
     }
 }

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/NodeIdConditionTest.java
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/java/no/sikt/graphitron/queries/fetch/NodeIdConditionTest.java
@@ -1,0 +1,87 @@
+package no.sikt.graphitron.queries.fetch;
+
+import no.sikt.graphitron.configuration.externalreferences.ExternalReference;
+import no.sikt.graphitron.generators.abstractions.ClassGenerator;
+import no.sikt.graphitron.reducedgenerators.InterfaceOnlyFetchDBClassGenerator;
+import no.sikt.graphitron.reducedgenerators.MapOnlyFetchDBClassGenerator;
+import no.sikt.graphql.schema.ProcessedSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static no.sikt.graphitron.common.configuration.ReferencedEntry.QUERY_FETCH_CONDITION;
+
+@DisplayName("Fetch query conditions on nodeId fields")
+public class NodeIdConditionTest extends NodeIdDirectiveTest {
+
+    @Override
+    protected String getSubpath() {
+        return "queries/fetch/conditions";
+    }
+
+    @Override
+    protected Set<ExternalReference> getExternalReferences() {
+        return makeReferences(QUERY_FETCH_CONDITION);
+    }
+
+    @Override
+    protected List<ClassGenerator> makeGenerators(ProcessedSchema schema) {
+        return List.of(new MapOnlyFetchDBClassGenerator(schema), new InterfaceOnlyFetchDBClassGenerator(schema));
+    }
+
+    @Test
+    @DisplayName("Node ID parameter is decoded to TableRecord when condition method expects TableRecord")
+    void onNodeIdParam() {
+        assertGeneratedContentContains(
+                "onNodeIdParam",
+                ".queryCustomerNodeId(_a_customer, _iv_nodeIdStrategy.nodeIdToTableRecord(_mi_customerId, \"C\", List.of(CUSTOMER.CUSTOMER_ID))))"
+        );
+    }
+
+    @Test
+    @DisplayName("Node ID parameter is passed as String when condition method expects String")
+    void onNodeIdParamAsString() {
+        assertGeneratedContentContains(
+                "onNodeIdParamAsString",
+                ".queryCustomerNodeIdAsString(_a_customer, _mi_customerId)"
+        );
+    }
+
+    @Test
+    @DisplayName("Listed Node ID parameter is decoded to TableRecords when condition method expects List<TableRecord>")
+    void onListedNodeIdParam() {
+        assertGeneratedContentContains(
+                "onListedNodeIdParam",
+                ".queryCustomerNodeIds(_a_customer, _mi_customerIds.stream().map(_iv_it -> _iv_nodeIdStrategy.nodeIdToTableRecord(_iv_it, \"C\", List.of(CUSTOMER.CUSTOMER_ID))).toList())"
+        );
+    }
+
+    @Test
+    @DisplayName("Listed Node ID parameter is passed as Strings when condition method expects List<String>")
+    void onListedNodeIdParamAsString() {
+        assertGeneratedContentContains(
+                "onListedNodeIdParamAsString",
+                ".queryCustomerNodeIdsAsString(_a_customer, _mi_customerIds)"
+        );
+    }
+
+    @Test
+    @DisplayName("Nested node ID parameter is decoded to TableRecord when condition method expects TableRecord")
+    void onNestedNodeIdParam() {
+        assertGeneratedContentContains(
+                "onNestedNodeIdParam",
+                ".queryCustomerNodeId(_a_customer, _iv_nodeIdStrategy.nodeIdToTableRecord("
+        );
+    }
+
+    @Test
+    @DisplayName("Nested node ID parameter is decoded to TableRecord and other input fields are passed through unchanged")
+    void onNestedNodeIdParamWithOtherField() {
+        assertGeneratedContentContains(
+                "onNestedNodeIdParamWithOtherField",
+                ".queryCustomerIdAndNodeId(_a_customer, _mi_filter.getCustomerId(), _iv_nodeIdStrategy.nodeIdToTableRecord("
+        );
+    }
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onListedNodeIdParam/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onListedNodeIdParam/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(customerIds: [ID!]! @nodeId(typeName: "Customer") @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerNodeIds"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onListedNodeIdParamAsString/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onListedNodeIdParamAsString/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(customerIds: [ID!]! @nodeId(typeName: "Customer") @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerNodeIdsAsString"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID!
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNestedNodeIdParam/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNestedNodeIdParam/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+  query(filter: CustomerInput! @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerNodeId"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID! @nodeId
+}
+
+input CustomerInput {
+  customerId: ID! @nodeId(typeName: "Customer")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNestedNodeIdParamWithOtherField/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNestedNodeIdParamWithOtherField/schema.graphqls
@@ -1,0 +1,12 @@
+type Query {
+  query(filter: CustomerInput! @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerIdAndNodeId"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID! @nodeId
+}
+
+input CustomerInput {
+  customerId: Int! @field(name: "CUSTOMER_ID")
+  customerNodeId: ID! @nodeId(typeName: "Customer")
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNodeIdParam/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNodeIdParam/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(customerId: ID! @nodeId(typeName: "Customer") @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerNodeId"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID! @nodeId
+}

--- a/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNodeIdParamAsString/schema.graphqls
+++ b/graphitron-codegen-parent/graphitron-java-codegen/src/test/resources/queries/fetch/conditions/onNodeIdParamAsString/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  query(customerId: ID! @nodeId(typeName: "Customer") @condition(condition: {name: "QUERY_FETCH_CONDITION", method: "queryCustomerNodeIdAsString"})): Customer
+}
+
+type Customer implements Node @node(typeId: "C") @table {
+  id: ID! @nodeId
+}

--- a/graphitron-common/src/main/java/no/sikt/graphql/NodeIdStrategy.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/NodeIdStrategy.java
@@ -92,6 +92,23 @@ public class NodeIdStrategy {
         setFields(record, id, typeId, idFields);
     }
 
+    /**
+     * Decode a node ID into a new table record, populating the supplied fields with the decoded key values.
+     *
+     * @throws IllegalArgumentException if {@code fields} is empty, if {@code typeId} does not match
+     *                                  the type encoded in {@code id}, or if the number of decoded
+     *                                  values does not match the number of fields.
+     */
+    public <T extends UpdatableRecordImpl<T>> T nodeIdToTableRecord(String id, String typeId, List<TableField<T, ?>> fields) {
+        T record = fields.stream().findFirst()
+                .map(TableField::getTable)
+                .map(RecordQualifier::newRecord)
+                .orElseThrow(() -> new IllegalArgumentException("Cannot decode node ID for typeId '" + typeId + "' without target fields"));
+
+        setFields(record, id, typeId, fields.toArray(Field[]::new));
+        return record;
+    }
+
     public void setReferenceId(UpdatableRecordImpl<?> record, String id, String typeId, Field<?>... idFields) {
         setFields(record, id, typeId, idFields);
     }

--- a/graphitron-common/src/test/java/no/sikt/graphql/NodeIdStrategyTest.java
+++ b/graphitron-common/src/test/java/no/sikt/graphql/NodeIdStrategyTest.java
@@ -4,6 +4,8 @@ import no.sikt.jooq.example.VacationDestinationRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static no.sikt.jooq.example.VacationDestination.VACATION_DESTINATION;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,6 +88,20 @@ class NodeIdStrategyTest {
         assertEquals(1, vacationDestinationRecord.getExtraKey());
 
         assertTrue(vacationDestinationRecord.changed());
+    }
+
+    @Test
+    @DisplayName("nodeIdToTableRecord creates a record with node ID fields populated")
+    void nodeIdIsMappedToTableRecord() {
+        var record = new NodeIdStrategy().nodeIdToTableRecord(
+                "VmFjYXRpb25EZXN0aW5hdGlvbjoxMjM0LE5vcndheQ==", // Decoded: VacationDestination:1234,Norway
+                "VacationDestination",
+                List.of(VACATION_DESTINATION.DESTINATION_ID, VACATION_DESTINATION.COUNTRY_NAME)
+        );
+
+        assertNotNull(record);
+        assertEquals(1234, record.getDestinationId());
+        assertEquals("Norway", record.getCountryName());
     }
 
     @Test

--- a/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestination.java
+++ b/graphitron-common/src/test/java/no/sikt/jooq/example/VacationDestination.java
@@ -28,6 +28,11 @@ public class VacationDestination extends TableImpl<VacationDestinationRecord> {
     }
 
     @Override
+    public Class<VacationDestinationRecord> getRecordType() {
+        return VacationDestinationRecord.class;
+    }
+
+    @Override
     public UniqueKey<VacationDestinationRecord> getPrimaryKey() {
         return Keys.VACATION_DESTINATION_PKEY;
     }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_nodeId_condition-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_nodeId_condition-1.result.approved.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "customerWithNextCustomerId": {
+            "id": "Q3VzdG9tZXI6Mg"
+        },
+        "customerWithSumOfCustomerIds": {
+            "id": "Q3VzdG9tZXI6Mw"
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_nodeId_condition.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_nodeId_condition.graphql
@@ -1,0 +1,9 @@
+# Test for custom conditions with node ID mapped to TableRecord
+{
+    customerWithNextCustomerId(customerId: "Q3VzdG9tZXI6MQ") { # Customer:1
+        id
+    }
+    customerWithSumOfCustomerIds(customerIds: ["Q3VzdG9tZXI6MQ", "Q3VzdG9tZXI6Mg"]) { # Customer:1, Customer:2
+        id
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/conditions/CustomerConditions.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/conditions/CustomerConditions.java
@@ -1,8 +1,11 @@
 package no.sikt.graphitron.example.service.conditions;
 
 import no.sikt.graphitron.example.generated.jooq.tables.Customer;
+import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
+
+import java.util.List;
 
 public class CustomerConditions {
     public static Condition activeCustomers(Customer customer) {
@@ -16,5 +19,17 @@ public class CustomerConditions {
     public static Condition inactiveCustomers(Customer customer, String lastNameStartingWith) {
         return inactiveCustomers(customer)
                 .and(lastNameStartingWith != null ? customer.LAST_NAME.startsWith(lastNameStartingWith) : DSL.noCondition());
+    }
+
+    public static Condition customerWithNextCustomerId(Customer customer, CustomerRecord id) {
+        return customer.CUSTOMER_ID.eq(id.getCustomerId() + 1);
+    }
+
+    public static Condition customerWithSumOfCustomerIds(Customer customer, List<CustomerRecord> customerNodeIds) {
+        return customer.CUSTOMER_ID.eq(customerNodeIds.stream().map(CustomerRecord::getCustomerId).reduce(0, Integer::sum));
+    }
+
+    public static Condition customerWithNextCustomerIdWithNodeIdString(Customer customer, String nodeId) {
+        return DSL.falseCondition(); // This method is only added to ensure we don't get a compilation error
     }
 }

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/conditions.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/conditions.graphql
@@ -1,0 +1,21 @@
+extend type Query {
+    activeCustomers: [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions", method: "activeCustomers"}, override: true)
+    inactiveCustomers(lastNameStartingWith: String): [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions"}, override: true)
+    staff(input: StaffInput!): [Staff] @asConnection
+
+    # Conditions with node ID
+    customerWithNextCustomerId(customerId: ID! @nodeId(typeName: "Customer") @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions", method: "customerWithNextCustomerId"}, override: true)): Customer
+    customerWithNextCustomerIdWithNodeIdString(customerId: ID! @nodeId(typeName: "Customer") @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions", method: "customerWithNextCustomerIdWithNodeIdString"}, override: true)): Customer
+    customerWithSumOfCustomerIds(customerIds: [ID!]! @nodeId(typeName: "Customer") @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions", method: "customerWithSumOfCustomerIds"}, override: true)): Customer
+}
+
+input StaffInput {
+    username: String
+    isManager: Boolean @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.StaffConditions", method: "isManagerOfAStore"}, override: true)
+    addressId: Int @field(name: "ADDRESS_ID") @reference(path: [{table: "ADDRESS"}])
+    withAddressIdInCity300: Int @field(name: "ADDRESS_ID") @reference(path: [{key: "STAFF__STAFF_ADDRESS_ID_FKEY"}]) @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.StaffConditions"})
+}
+
+extend type Store {
+    inactiveCustomers: [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions"}, override: true)
+}

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
@@ -11,8 +11,6 @@ type Query {
     helloWorld: String @notGenerated
 
     customers(first: Int = 100, after: String): CustomerConnection
-    activeCustomers: [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions", method: "activeCustomers"}, override: true)
-    inactiveCustomers(lastNameStartingWith: String): [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions"}, override: true)
     customersByAddress(addressId: ID! @nodeId(typeName: "Address")): [Customer] @asConnection
     customerWithJooqRecordInput(input: CustomerInput!): [Customer] @asConnection
     customerWithJavaRecordInput(input: CustomerJavaRecordInput!): [Customer] @asConnection
@@ -34,8 +32,6 @@ type Query {
 
     payments(dateTime: LocalDateTime @field(name: "PAYMENT_DATE"), amount: BigDecimal): [Payment] @asConnection
     paymentsFilteredByInventory(inventoryId: Int @field(name: "inventory_id") @reference(path: [{table: "RENTAL"}])): [Payment] @asConnection
-
-    staff(input: StaffInput!): [Staff] @asConnection
 
     node(id: ID!): Node
     cities: [City] @asConnection
@@ -216,13 +212,6 @@ type Payment @table {
 #    customer: CustomerRecord @splitQuery @service(service: {className: "no.sikt.graphitron.example.service.CustomerService"}) # kommentert ut pga bug i mapper
 }
 
-input StaffInput {
-    username: String
-    isManager: Boolean @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.StaffConditions", method: "isManagerOfAStore"}, override: true)
-    addressId: Int @field(name: "ADDRESS_ID") @reference(path: [{table: "ADDRESS"}])
-    withAddressIdInCity300: Int @field(name: "ADDRESS_ID") @reference(path: [{key: "STAFF__STAFF_ADDRESS_ID_FKEY"}]) @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.StaffConditions"})
-}
-
 type Staff implements Node @node @table(name: "STAFF") {
     id: ID! @nodeId
     email: String
@@ -251,7 +240,6 @@ type FilmCategory implements Node @node @table(name: "FILM_CATEGORY") {
 
 type Store implements Node @node @table {
     id: ID! @nodeId
-    inactiveCustomers: [Customer] @asConnection @condition(condition: {className: "no.sikt.graphitron.example.service.conditions.CustomerConditions"}, override: true)
 }
 
 type Rental @table {


### PR DESCRIPTION
## Overview
**Related issue**: GG-430
**Issue coverage**: closes
**Backwards compatibility**: yes

## Summary
Conditions with `@nodeId` argument can now declare the parameter as a jOOQ `TableRecord` (or `List<X>` of one), and Graphitron decodes the encoded node ID into a populated record before invoking the method. Methods declaring `String` or `List<String>` continue to receive the raw encoded ID, so existing conditions are unaffected.

## Notes
- Bundles a small unrelated example-app schema cleanup: `Query.activeCustomers`, `Query.inactiveCustomers`, `Query.staff`, `input StaffInput`, and `Store.inactiveCustomers` move from `schema.graphqls` into a new `conditions.graphql` so the new node-ID-conditioned queries land alongside their siblings.