### PR TITLE
GG-450 normalize resolver keys coming from services

### DIFF
--- a/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/ServiceDataFetcherHelper.java
+++ b/graphitron-common/src/main/java/no/sikt/graphql/helpers/resolvers/ServiceDataFetcherHelper.java
@@ -6,6 +6,7 @@ import no.sikt.graphql.helpers.selection.SelectionSet;
 import no.sikt.graphql.helpers.transform.AbstractTransformer;
 import no.sikt.graphql.relay.ConnectionImpl;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jooq.UpdatableRecord;
 
 import java.util.List;
 import java.util.Map;
@@ -205,12 +206,34 @@ public class ServiceDataFetcherHelper<A extends AbstractTransformer> extends Abs
             return CompletableFuture.completedFuture(Map.of());
         }
 
-        var idSet = keys.stream().map(KeyWithPath::key).collect(Collectors.toSet());
         return CompletableFuture.completedFuture(
-                resultAsMap(keys, dbFunction.apply(idSet))
+                resultAsMapWithPkOnlyKeys(keys, dbFunction)
                         .entrySet()
                         .stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, it -> dbTransform.transform(abstractTransformer, it.getValue())))
         );
+    }
+
+    /**
+     * Like {@link #resultAsMap}, but strips non-PK columns from {@link UpdatableRecord} keys
+     * returned by the service so equality with the requested PK-only lookup keys holds.
+     */
+    protected <K, V> Map<KeyWithPath<K>, V> resultAsMapWithPkOnlyKeys(Set<KeyWithPath<K>> keys, Function<Set<K>, Map<K, V>> dbFunction) {
+        var keySet = keys.stream().map(KeyWithPath::key).collect(Collectors.toSet());
+        var stripped = dbFunction.apply(keySet).entrySet().stream()
+                .collect(Collectors.toMap(e -> stripNonPkColumns(e.getKey()), Map.Entry::getValue));
+        return resultAsMap(keys, stripped);
+    }
+
+    /**
+     * Returns an {@link UpdatableRecord} key with non-PK columns stripped; other keys are
+     * returned unchanged.
+     */
+    @SuppressWarnings("unchecked")
+    static <K> K stripNonPkColumns(K key) {
+        if (key instanceof UpdatableRecord<?> record) {
+            return (K) record.key().into(record.getClass());
+        }
+        return key;
     }
 }

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_with_mixed_resolver_keys-1.result.approved.json
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/approvals/query_service_with_mixed_resolver_keys-1.result.approved.json
@@ -1,0 +1,30 @@
+{
+    "data": {
+        "filmActorLookup": [
+            {
+                "id": "RmlsbUFjdG9yOjEsMQ",
+                "filmsWithMixedResolverKeys": null
+            },
+            {
+                "id": "RmlsbUFjdG9yOjEwLDE",
+                "filmsWithMixedResolverKeys": null
+            },
+            {
+                "id": "RmlsbUFjdG9yOjIwLDE",
+                "filmsWithMixedResolverKeys": [
+                    {
+                        "id": "RmlsbTox"
+                    }
+                ]
+            },
+            {
+                "id": "RmlsbUFjdG9yOjMwLDE",
+                "filmsWithMixedResolverKeys": [
+                    {
+                        "id": "RmlsbTox"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_with_mixed_resolver_keys.graphql
+++ b/graphitron-example/graphitron-example-server/src/test/resources/approval/queries/query_service_with_mixed_resolver_keys.graphql
@@ -1,0 +1,16 @@
+# Tests dataloader normalization for service-returned keys with various shapes:
+# null, partial PK, PK + non-PK populated, PK only. Only the latter two should
+# resolve to a Film. Exercises composite-PK stripping via FilmActor.
+{
+    filmActorLookup(ids: [
+        "RmlsbUFjdG9yOjEsMQ",
+        "RmlsbUFjdG9yOjEwLDE",
+        "RmlsbUFjdG9yOjIwLDE",
+        "RmlsbUFjdG9yOjMwLDE"
+    ]) {
+        id
+        filmsWithMixedResolverKeys {
+            id
+        }
+    }
+}

--- a/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
+++ b/graphitron-example/graphitron-example-service/src/main/java/no/sikt/graphitron/example/service/MockService.java
@@ -3,10 +3,13 @@ package no.sikt.graphitron.example.service;
 import no.sikt.graphitron.example.generated.jooq.tables.records.AddressRecord;
 import no.sikt.graphitron.example.generated.jooq.tables.records.CityRecord;
 import no.sikt.graphitron.example.generated.jooq.tables.records.CustomerRecord;
+import no.sikt.graphitron.example.generated.jooq.tables.records.FilmActorRecord;
 import no.sikt.graphitron.example.generated.jooq.tables.records.FilmRecord;
 import no.sikt.graphitron.example.service.records.MockUpdateAddressAndCustomerResultRecord;
 import org.jooq.DSLContext;
 
+import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +35,39 @@ public class MockService {
                     return List.of(film);
                 }
         ));
+    }
+
+    /**
+     * Returns a hardcoded mix of resolver-key shapes to exercise dataloader normalization:
+     * null, partial PK (one PK column null), PK + non-PK column populated, PK only.
+     * Only the latter two should resolve to a Film. The incoming keys are intentionally
+     * ignored — the dataloader is responsible for matching these against whatever was
+     * actually requested via PK normalization.
+     */
+    public Map<FilmActorRecord, List<FilmRecord>> filmsWithMixedResolverKeys(Set<FilmActorRecord> keys) {
+        var film = new FilmRecord();
+        film.setFilmId("1");
+        film.setTitle("Film from service");
+        var films = List.of(film);
+
+        var partialPk = new FilmActorRecord();
+        partialPk.setActorId(10);
+
+        var pkPlusNonPk = new FilmActorRecord();
+        pkPlusNonPk.setActorId(20);
+        pkPlusNonPk.setFilmId(1);
+        pkPlusNonPk.setLastUpdate(LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        var pkOnly = new FilmActorRecord();
+        pkOnly.setActorId(30);
+        pkOnly.setFilmId(1);
+
+        var result = new HashMap<FilmActorRecord, List<FilmRecord>>();
+        result.put(null, films);
+        result.put(partialPk, films);
+        result.put(pkPlusNonPk, films);
+        result.put(pkOnly, films);
+        return result;
     }
 
     public MockUpdateAddressAndCustomerResultRecord mockUpdateAddressAndCustomer() {

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/schema.graphqls
@@ -23,6 +23,8 @@ type Query {
     filmLookupWithAdditionalField(filmId: [String!]! @lookupKey @field(name: "FILM_ID"), title: [String!] @lookupKey): [Film]
     filmLookupWithInputObject(filmIds: [FilmLookupInput] @lookupKey): [Film]
 
+    filmActorLookup(ids: [ID!]! @lookupKey @nodeId(typeName: "FilmActor")): [FilmActor]
+
     filmLists(category: String, categoryAsId: ID @field(name: "CATEGORY")): [FilmList]
     filmListsWithEnumRecord(input: FilmListEnumInput!): FilmList
     filmsWithDescriptionInput(input: [FilmDescriptionInput]): [Film]

--- a/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
+++ b/graphitron-example/graphitron-example-spec/src/main/resources/graphql/services.graphql
@@ -281,3 +281,12 @@ extend type City {
     filmsFromCity: [Film!]! @splitQuery @service(service: {className: "no.sikt.graphitron.example.service.MockService", method: "filmsFromCity"}) # Non-nullable for loadNonNullable approval test
     filmsFromCityByYear(year: Int @field(name: "RELEASE_YEAR")): [Film] @splitQuery @service(service: {className: "no.sikt.graphitron.example.service.MockService", method: "filmsFromCityByYear"})
 }
+
+extend type FilmActor {
+    """
+    Service exercising mixed resolver-key shapes returned by the implementation:
+    null, partial PK (one PK column null), PK + non-PK column populated, and PK only.
+    Only the latter two should resolve to a Film.
+    """
+    filmsWithMixedResolverKeys: [Film] @splitQuery @service(service: {className: "no.sikt.graphitron.example.service.MockService"})
+}


### PR DESCRIPTION
## Overview
**Related issue**: GG-450
**Issue coverage**: closes
**Backwards compatibility**: yes

## Summary
`ServiceDataFetcherHelper` matched service results to requested keys via `Map.get`, which uses jOOQ's field-wise `UpdatableRecord` equality. A service that returned a key with non-PK columns populated would not compare equal to the PK-only requested key, so the resolver silently returned null for that entry. The fix projects each `UpdatableRecord` result key down to its PK before matching.