### PR TITLE
Fix CLI gunzip step in natives-release workflow

### DIFF
--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -66,13 +66,15 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/ts-cli"
           cd "$RUNNER_TEMP/ts-cli"
-          url="https://github.com/tree-sitter/tree-sitter/releases/download/${{ inputs.tree-sitter-cli-version }}/${{ matrix.cli-asset }}"
-          curl -fsSL -o asset "$url"
-          if [[ "${{ matrix.cli-asset }}" == *.zip ]]; then
-            unzip -q asset
+          asset="${{ matrix.cli-asset }}"
+          url="https://github.com/tree-sitter/tree-sitter/releases/download/${{ inputs.tree-sitter-cli-version }}/${asset}"
+          curl -fsSL -o "$asset" "$url"
+          if [[ "$asset" == *.zip ]]; then
+            unzip -q "$asset"
           else
-            gunzip asset
-            mv asset "${{ matrix.cli-binary }}"
+            # gunzip needs the .gz suffix to know what to do; it strips it on success.
+            gunzip "$asset"
+            mv "${asset%.gz}" "${{ matrix.cli-binary }}"
           fi
           chmod +x "${{ matrix.cli-binary }}" || true
           ls -la


### PR DESCRIPTION
## Summary

The first dry-run of the `tree-sitter natives release` workflow failed on the CLI download step:

```
gzip: asset: unknown suffix -- ignored
```

`gunzip` refuses to decompress a file without a `.gz` suffix. The previous script downloaded the asset into a file literally named `asset`, then called `gunzip asset`, which bailed.

Fix: download into the original asset name (`tree-sitter-linux-x64.gz`, `tree-sitter-macos-arm64.gz`, …), gunzip in place, then `mv` the decompressed file (suffix stripped by gunzip) to the platform-specific binary name. No behavior change on the `.zip` (Windows) branch.

## Test plan

- [ ] Re-trigger `tree-sitter natives release` against `claude/graphitron-rewrite` with `dry-run: true`. The five-platform build matrix should now get past CLI download and reach `tree-sitter build`.
- [ ] On success, the package + jar-layout assertion job runs; deploy and post-deploy-verify remain skipped under `dry-run`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TmSNnHp9AePG7xQS81AVcz)_