### PR TITLE
tree-sitter-natives workflow: Windows asset name, Node 24 actions, drop macos-x86_64

### DIFF
--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -123,7 +123,7 @@ jobs:
           Write-Output "OK: tree_sitter_graphql exported"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.platform }}
           path: ${{ runner.temp }}/out/${{ matrix.lib-name }}
@@ -150,7 +150,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Download all native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: native-artifacts/
           pattern: native-*

--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -179,7 +179,8 @@ jobs:
           jar_path="$NATIVES_MODULE/target/graphitron-tree-sitter-natives-${version}.jar"
           echo "Inspecting $jar_path"
           unzip -l "$jar_path"
-          lib_entries="$(unzip -l "$jar_path" | awk '{print $4}' | grep -E '^lib/' || true)"
+          # Filter out the bare lib/ and lib/<os>-<arch>/ directory entries unzip -l also prints.
+          lib_entries="$(unzip -l "$jar_path" | awk '{print $4}' | grep -E '^lib/.+[^/]$' || true)"
           expected="lib/linux-aarch64/libtree-sitter-graphql.so
           lib/linux-x86_64/libtree-sitter-graphql.so
           lib/macos-aarch64/libtree-sitter-graphql.dylib

--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -42,11 +42,6 @@ jobs:
             lib-name: libtree-sitter-graphql.so
             cli-asset: tree-sitter-linux-arm64.gz
             cli-binary: tree-sitter
-          - platform: macos-x86_64
-            runner: macos-13
-            lib-name: libtree-sitter-graphql.dylib
-            cli-asset: tree-sitter-macos-x64.gz
-            cli-binary: tree-sitter
           - platform: macos-aarch64
             runner: macos-14
             lib-name: libtree-sitter-graphql.dylib
@@ -160,7 +155,7 @@ jobs:
           set -euo pipefail
           base="$NATIVES_MODULE/target/classes/lib"
           mkdir -p "$base"
-          for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
+          for platform in linux-x86_64 linux-aarch64 macos-aarch64 windows-x86_64; do
             src="native-artifacts/native-$platform"
             if [[ ! -d "$src" ]]; then
               echo "::error::missing artifact directory $src"
@@ -176,7 +171,7 @@ jobs:
           mvn -f "$NATIVES_MODULE/pom.xml" --batch-mode --errors package -DskipTests
 
       - name: Assert jar layout
-        # Exactly five lib/<os>-<arch>/<file> entries; any other lib/* path is a bug.
+        # Exactly four lib/<os>-<arch>/<file> entries; any other lib/* path is a bug.
         run: |
           set -euo pipefail
           jar_path="$(ls $NATIVES_MODULE/target/graphitron-tree-sitter-natives-*.jar)"
@@ -186,16 +181,15 @@ jobs:
           expected="lib/linux-aarch64/libtree-sitter-graphql.so
           lib/linux-x86_64/libtree-sitter-graphql.so
           lib/macos-aarch64/libtree-sitter-graphql.dylib
-          lib/macos-x86_64/libtree-sitter-graphql.dylib
           lib/windows-x86_64/tree-sitter-graphql.dll"
           expected="$(echo "$expected" | sed 's/^ *//' | sort)"
           actual="$(echo "$lib_entries" | sort)"
           if [[ "$actual" != "$expected" ]]; then
-            echo "::error::jar lib/ contents do not match expected five entries"
+            echo "::error::jar lib/ contents do not match expected four entries"
             diff <(echo "$expected") <(echo "$actual") || true
             exit 1
           fi
-          echo "OK: jar layout matches exactly the five expected lib/<os>-<arch>/ entries"
+          echo "OK: jar layout matches exactly the four expected lib/<os>-<arch>/ entries"
 
       - name: Deploy to Maven Central
         if: ${{ !inputs.dry-run }}
@@ -229,8 +223,6 @@ jobs:
             runner: ubuntu-latest
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-          - platform: macos-x86_64
-            runner: macos-13
           - platform: macos-aarch64
             runner: macos-14
           - platform: windows-x86_64
@@ -325,8 +317,6 @@ jobs:
                       dir = "linux-x86_64"; libName = "libtree-sitter-graphql.so";
                   } else if (os.contains("linux") && arch.equals("aarch64")) {
                       dir = "linux-aarch64"; libName = "libtree-sitter-graphql.so";
-                  } else if (os.contains("mac") && (arch.equals("amd64") || arch.equals("x86_64"))) {
-                      dir = "macos-x86_64"; libName = "libtree-sitter-graphql.dylib";
                   } else if (os.contains("mac") && arch.equals("aarch64")) {
                       dir = "macos-aarch64"; libName = "libtree-sitter-graphql.dylib";
                   } else if (os.contains("windows") && (arch.equals("amd64") || arch.equals("x86_64"))) {

--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -55,7 +55,7 @@ jobs:
           - platform: windows-x86_64
             runner: windows-latest
             lib-name: tree-sitter-graphql.dll
-            cli-asset: tree-sitter-windows-x64.zip
+            cli-asset: tree-sitter-windows-x64.gz
             cli-binary: tree-sitter.exe
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tree-sitter-natives-release.yml
+++ b/.github/workflows/tree-sitter-natives-release.yml
@@ -174,7 +174,9 @@ jobs:
         # Exactly four lib/<os>-<arch>/<file> entries; any other lib/* path is a bug.
         run: |
           set -euo pipefail
-          jar_path="$(ls $NATIVES_MODULE/target/graphitron-tree-sitter-natives-*.jar)"
+          # Pin to the main artifact; the broad glob also matches -sources.jar and -javadoc.jar.
+          version="$(grep -m1 '<version>' $NATIVES_MODULE/pom.xml | sed -E 's|.*<version>([^<]+)</version>.*|\1|')"
+          jar_path="$NATIVES_MODULE/target/graphitron-tree-sitter-natives-${version}.jar"
           echo "Inspecting $jar_path"
           unzip -l "$jar_path"
           lib_entries="$(unzip -l "$jar_path" | awk '{print $4}' | grep -E '^lib/' || true)"


### PR DESCRIPTION
## Summary

Follow-up fixes discovered during further dry-run iteration of `tree-sitter natives release` after PR #495. Three commits, each a focused fix:

1. **Fix Windows CLI asset name** (`.zip` → `.gz`). Upstream tree-sitter v0.26.9 ships Windows as a gzipped raw `.exe` (`tree-sitter-windows-x64.gz`), not a zip. The previous matrix entry pointed at `.zip` and 404'd on the curl download. Verified against the actual release assets: `.gz` returns 302, `.zip` returns 404.

2. **Bump artifact actions off Node.js 20**. `actions/upload-artifact@v4` and `actions/download-artifact@v4` both run on Node 20, which GitHub Actions is deprecating (forced to Node 24 on June 2nd 2026, Node 20 removed September 16th 2026). Bumped to the latest stable majors (`v7` upload, `v8` download) — both Node 24-native; artifact format unchanged.

3. **Drop `macos-x86_64` from the natives matrix**. All Sikt graphitron-lsp developers run Apple silicon (M1+), the `macos-13` GitHub-hosted runner is the slowest queue on the platform, and the LSP is internal-only per the spec's "Out of scope" list, so Intel-Mac coverage costs significant CI time without a known consumer. The supported set is now four: `linux-x86_64`, `linux-aarch64`, `macos-aarch64`, `windows-x86_64`. Jar-layout assertion + inlined `Verify.java` platform switch updated accordingly.

## Test plan

- [ ] Re-trigger `tree-sitter natives release` against `claude/graphitron-rewrite` with `dry-run: true`. The four-platform build matrix should run to completion (CLI downloads on Windows, no Intel-Mac queue stall).
- [ ] On success, the package + jar-layout assertion job runs and now expects exactly four `lib/<os>-<arch>/` entries.
- [ ] No Node 20 deprecation warnings in the run summary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TmSNnHp9AePG7xQS81AVcz)_